### PR TITLE
fix(web): keep thread message bodies inside the thread panel width

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -153,7 +153,11 @@ main.content-col{display:flex;flex-direction:column;height:100vh;background:var(
 .mav.agent{background:radial-gradient(circle at 30% 28%,var(--g-mint),var(--g-lav) 70%,var(--g-sky))}
 .mav.human{background:var(--surface-strong);color:var(--muted)}.mav.system{background:var(--surface-strong);color:var(--muted-soft)}
 .who{font-weight:600;font-size:16px;color:var(--ink)} .ts{font-size:12px;color:var(--muted-soft);margin-left:8px}
-.mbody{white-space:pre-wrap;color:var(--body)}
+/* overflow-wrap:anywhere (inherited by .md and all descendants): break long unbreakable tokens
+   — URLs, file paths, IDs — so a single token can't blow the body past a narrow column, most
+   visibly the 320px thread panel. Pairs with .msg-col's min-width:0; does not affect explicit
+   line breaks in code blocks. */
+.mbody{white-space:pre-wrap;color:var(--body);overflow-wrap:anywhere}
 /* Message body markdown (MessageContent .md): react-markdown+remark-breaks already structures line breaks, explicit white-space:normal overrides pre-wrap inherited from .mbody — otherwise consecutive blank lines/paragraphs are double-preserved and inflate height (diagnosed: .md inherits pre-wrap + p default 16px margin → 3 paragraphs = 176px). Paragraph/list spacing tightened for compact body; code blocks retain their own line breaks */
 .md{white-space:normal}
 .md > :first-child{margin-top:0}.md > :last-child{margin-bottom:0}

--- a/web/src/views/Chat.tsx
+++ b/web/src/views/Chat.tsx
@@ -535,7 +535,8 @@ function ThreadPanel({ channelId, parent, onClose, onOpenProfile }: { channelId:
     return (
     <div className="msg" key={m.id}>
       {ag ? <span className="msg-av clickable" onClick={() => onOpenProfile(m.senderId!)}><Avatar seed={m.senderName} size={32} /></span> : <Avatar seed={m.senderName} size={32} />}
-      <div>
+      {/* content column reuses .msg-col (flex:1;min-width:0) like the main chat — without it a flex child defaults to min-width:auto and a long unbreakable token blows the message past this narrow thread panel */}
+      <div className="msg-col">
         <div>{ag ? <span className="who clickable" onClick={() => onOpenProfile(m.senderId!)}>{m.senderName}</span> : <span className="who">{m.senderName}</span>}<span className="ts">{fmtTime(m.createdAt)}</span></div>
         {!!m.content && <div className="mbody"><MessageContent content={m.content} agents={agents} humans={humans} channels={channels} nav={navToken} /></div>}
         {!!m.attachments?.length && <div className="msg-atts">{m.attachments.map((a) => <AttCard key={a.id} a={a} url={attachmentUrl(a.id)} />)}</div>}


### PR DESCRIPTION
## Problem

In the Thread panel, replies containing a long unbreakable token (a URL, or a slash path like `README/AGENTS/ARCHITECTURE/CONTRIBUTING`) overflow the ~320px panel, while plain CJK replies don't — the inconsistent "some overflow, some don't" rendering reported in #7.

## Root cause

`ThreadPanel.row()` rendered the message content column as a bare `<div>`, while the main chat uses `<div className="msg-col">` (`.msg-col { flex:1; min-width:0 }`). `.msg` is a flexbox; a flex child defaults to `min-width:auto` (= min-content), so a long-token message can't shrink and blows out the column. Additionally `.mbody`/`.md` never set `overflow-wrap`, so a single unbreakable token overflows even once the column can shrink.

Isolated repro against the real stylesheet, 320px column:

| content column | column width | `.scroll` horizontal overflow |
|---|---|---|
| bare `<div>` (before) | 441px (forced open) | **+194px** |
| `.msg-col` only (`min-width:0`) | 204px | still **+209px** |
| `.msg-col` + `overflow-wrap:anywhere` | 219px | **0px** |

`min-width:0` alone is not enough — the long token still overflows the shrunk column, so both layers are needed.

## Solution — two layers, reusing existing conventions

1. **`Chat.tsx`** — the thread content column reuses `.msg-col`, matching the main chat. Gives it `flex:1; min-width:0` so it can shrink, and a definite width for a code block's `overflow:auto`.
2. **`styles.css`** — `.mbody` gets `overflow-wrap:anywhere`. `overflow-wrap` is inherited, so `.md` and all descendants pick it up and long unbreakable tokens wrap. This also hardens the main chat against pathological URLs/IDs. It does not affect explicit line breaks in code blocks.

Diff is 2 files, +7 / −2.

## Validation

- `npm run typecheck` (root + web) — clean ✅
- `npm run build` (web) — clean ✅ (the "chunks larger than 500 kB" notice is pre-existing and unrelated to this change)
- Browser repro against the **real** `styles.css`: with the fix, the thread column reports `scrollWidth == clientWidth` (0px horizontal overflow) for (a) the original screenshot message, (b) a 200-char bare URL, (c) a code block. Plain CJK replies are unchanged.

## Doc-sync

No impact: pure rendering fix — no schema / route / CLI / daemon / module-boundary change. `FEATURES.md`, `README.md`, and `docs/tech-debt-tracker.md` are unaffected (the bug was not previously tracked).

Closes #7
