### PR TITLE
feat: show agent avatar in head + avatar upload for agents and humans

### DIFF
--- a/src/server/routes-api.ts
+++ b/src/server/routes-api.ts
@@ -556,6 +556,31 @@ export async function handleApi(req: IncomingMessage, res: ServerResponse, url: 
     }
     return (sendJson(res, 200, { attachments: out, attachmentId: out[0]?.attachmentId }), true);
   }
+  // Agent avatar upload: manageAgents capability required → stored as attachment → agents.avatarUrl
+  const agavatar = /^\/api\/agents\/([^/]+)\/avatar$/.exec(p);
+  if (agavatar && method === "POST") {
+    if (!await requireCap(serverId, userId, "manageAgents")) return (sendErr(res, 403, "need manageAgents capability"), true);
+    const agentId = agavatar[1]!;
+    const { files } = await parseUpload(req);
+    const f = files[0];
+    if (!f) return (sendErr(res, 400, "no file"), true);
+    if (!(f.mimeType || "").startsWith("image/")) return (sendErr(res, 400, "avatar must be an image"), true);
+    const [att] = await db.insert(schema.attachments).values({ serverId, channelId: null, uploaderType: "user", uploaderId: userId, filename: f.filename, mimeType: f.mimeType, sizeBytes: f.size, storageKey: f.storageKey }).returning();
+    const avatarUrl = `/api/attachments/${att!.id}`;
+    await db.update(schema.agents).set({ avatarUrl }).where(and(eq(schema.agents.id, agentId), eq(schema.agents.serverId, serverId)));
+    return (sendJson(res, 200, { avatarUrl }), true);
+  }
+  // Current user avatar upload → stored as attachment → users.avatarUrl
+  if (p === "/api/auth/me/avatar" && method === "POST") {
+    const { files } = await parseUpload(req);
+    const f = files[0];
+    if (!f) return (sendErr(res, 400, "no file"), true);
+    if (!(f.mimeType || "").startsWith("image/")) return (sendErr(res, 400, "avatar must be an image"), true);
+    const [att] = await db.insert(schema.attachments).values({ serverId, channelId: null, uploaderType: "user", uploaderId: userId, filename: f.filename, mimeType: f.mimeType, sizeBytes: f.size, storageKey: f.storageKey }).returning();
+    const avatarUrl = `/api/attachments/${att!.id}`;
+    await db.update(schema.users).set({ avatarUrl }).where(eq(schema.users.id, userId));
+    return (sendJson(res, 200, { avatarUrl }), true);
+  }
   // Workspace avatar upload: owner/admin uploads image → stored as attachment → servers.avatarUrl
   const savatar = /^\/api\/servers\/([^/]+)\/avatar$/.exec(p);
   if (savatar && method === "POST") {

--- a/web/src/Avatar.tsx
+++ b/web/src/Avatar.tsx
@@ -11,7 +11,7 @@ function uriFor(seed: string): string {
   return u;
 }
 
-export function Avatar({ seed, size = 24 }: { seed: string; size?: number }) {
+export function Avatar({ seed, size = 24, url }: { seed: string; size?: number; url?: string | null }) {
   const uri = useMemo(() => uriFor(seed), [seed]);
-  return <img className="av-img" src={uri} width={size} height={size} alt={seed} title={seed} />;
+  return <img className="av-img" src={url || uri} width={size} height={size} alt={seed} title={seed} />;
 }

--- a/web/src/store.tsx
+++ b/web/src/store.tsx
@@ -19,6 +19,8 @@ interface Store {
   ready: boolean; serverId: string; slug: string; me: Me | null; myRole: string; serverAvatar: string | null;
   servers: ServerInfo[]; capabilities: Record<string, boolean>;
   uploadServerAvatar: (file: File) => Promise<void>;
+  uploadAgentAvatar: (agentId: string, file: File) => Promise<string>;
+  uploadUserAvatar: (file: File) => Promise<string>;
   createServer: (name: string, slug?: string) => Promise<void>;
   logout: () => void;
   channels: Channel[]; dms: Dm[]; unread: Record<string, number>; agents: Agent[]; machines: Machine[]; humans: Human[];
@@ -122,6 +124,20 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     if (!r.ok) throw new Error((await r.json().catch(() => ({})))?.error || "upload failed");
     const { avatarUrl } = await r.json();
     setServerAvatar(avatarUrl ? `${avatarUrl}?token=${encodeURIComponent(tokenRef.current)}` : null);
+  };
+  const uploadAgentAvatar = async (agentId: string, file: File): Promise<string> => {
+    const fd = new FormData(); fd.append("files", file);
+    const r = await fetch(`/api/agents/${agentId}/avatar`, { method: "POST", headers: { authorization: "Bearer " + tokenRef.current, "x-server-id": sidRef.current }, body: fd });
+    if (!r.ok) throw new Error((await r.json().catch(() => ({})))?.error || "upload failed");
+    const { avatarUrl } = await r.json();
+    return `${avatarUrl}?token=${encodeURIComponent(tokenRef.current)}`;
+  };
+  const uploadUserAvatar = async (file: File): Promise<string> => {
+    const fd = new FormData(); fd.append("files", file);
+    const r = await fetch("/api/auth/me/avatar", { method: "POST", headers: { authorization: "Bearer " + tokenRef.current, "x-server-id": sidRef.current }, body: fd });
+    if (!r.ok) throw new Error((await r.json().catch(() => ({})))?.error || "upload failed");
+    const { avatarUrl } = await r.json();
+    return `${avatarUrl}?token=${encodeURIComponent(tokenRef.current)}`;
   };
   const react = async (messageId: string, emoji: string, remove = false) => { await api(remove ? "DELETE" : "POST", `/api/messages/${messageId}/reactions`, { emoji }); };
   const openThread = async (parentChannelId: string, parentMessageId: string) => { const r = await api("POST", `/api/channels/${parentChannelId}/threads`, { parentMessageId }); return r?.threadChannelId ?? null; };
@@ -232,7 +248,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     return () => { cancelled = true; sock?.close(); if (unreadTimer) clearTimeout(unreadTimer); };
   }, []);
 
-  return <Ctx.Provider value={{ ready, serverId, slug, me, myRole, serverAvatar, servers, capabilities, createServer, logout, uploadServerAvatar, channels, dms, unread, agents, machines, humans, api, reload, onEvent, subscribeChannel, createChannel, markActionExecuted, createTasks, openDM, joinChannel, leaveChannel, markRead, uploadFiles, uploadOne, attachmentUrl, react, openThread, savedIds, saveMsg, unsaveMsg, listSaved }}>{children}</Ctx.Provider>;
+  return <Ctx.Provider value={{ ready, serverId, slug, me, myRole, serverAvatar, servers, capabilities, createServer, logout, uploadServerAvatar, uploadAgentAvatar, uploadUserAvatar, channels, dms, unread, agents, machines, humans, api, reload, onEvent, subscribeChannel, createChannel, markActionExecuted, createTasks, openDM, joinChannel, leaveChannel, markRead, uploadFiles, uploadOne, attachmentUrl, react, openThread, savedIds, saveMsg, unsaveMsg, listSaved }}>{children}</Ctx.Provider>;
 }
 
 export const fmtTime = (iso?: string) => { try { return iso ? new Date(iso).toLocaleTimeString("zh-CN", { hour12: false }) : ""; } catch { return ""; } };

--- a/web/src/views/Members.tsx
+++ b/web/src/views/Members.tsx
@@ -115,7 +115,7 @@ function Roster({ agents, onCreate, canCreate }: { agents: any[]; onCreate: () =
 
 export function AgentProfile({ id, onDeleted, onClose, onMessage }: { id: string; onDeleted: () => void; onClose?: () => void; onMessage?: () => void }) {
   const { t } = useTranslation();
-  const { api, reload, onEvent, capabilities, openDM, slug } = useStore();
+  const { api, reload, onEvent, capabilities, openDM, slug, uploadAgentAvatar, attachmentUrl } = useStore();
   const confirm = useConfirm();
   const nav = useNavigate();
   const [sp, setSp] = useSearchParams();
@@ -123,9 +123,12 @@ export function AgentProfile({ id, onDeleted, onClose, onMessage }: { id: string
   const [a, setA] = useState<any>(null);
   const [edit, setEdit] = useState(false); const [dn, setDn] = useState(""); const [ds, setDs] = useState(""); // profile edit state (displayName/description)
   const [showRestart, setShowRestart] = useState(false);
-  const refetch = async () => setA(await api("GET", "/api/agents/" + id));
+  const [avBusy, setAvBusy] = useState(false); const [avErr, setAvErr] = useState(""); const [signedAvatar, setSignedAvatar] = useState<string | null>(null);
+  const avFileRef = useRef<HTMLInputElement>(null);
+  const refetch = async () => { const data = await api("GET", "/api/agents/" + id); setA(data); setSignedAvatar(data?.avatarUrl ? attachmentUrl(data.avatarUrl.replace("/api/attachments/", "")) : null); };
   useEffect(() => { refetch(); }, [id]);
   useEffect(() => onEvent((e) => { if (e.type === "agent" && e.id === id) setA((p: any) => (p ? { ...p, status: e.status ?? p.status, activity: e.activity ?? p.activity } : p)); }), [id]);
+  const onPickAvatar = async (e: any) => { const f = e.target.files?.[0]; e.target.value = ""; if (!f) return; setAvBusy(true); setAvErr(""); try { const url = await uploadAgentAvatar(id, f); setSignedAvatar(url); await refetch(); } catch (err: any) { setAvErr(String(err?.message || err)); } finally { setAvBusy(false); } };
   if (!a) return <div className="scroll"><div className="empty">{t("members.loading")}</div></div>;
   const ctl = async (action: string) => { await api("POST", `/api/agents/${id}/${action}`); setTimeout(refetch, 400); };
   // Three restart modes: restart=keep session+workspace; reset=clear session, keep workspace; full=clear session+delete workspace. All modes end with a restart.
@@ -156,12 +159,12 @@ export function AgentProfile({ id, onDeleted, onClose, onMessage }: { id: string
     <>
       {onClose ? ( // panel mode (embedded in chat right sidebar: click avatar → profile panel)
         <div className="profile-panel-head">
-          <Avatar seed={a.name} size={28} />
+          <Avatar seed={a.name} url={signedAvatar} size={28} />
           <div className="pph-id"><span className="pph-name">{a.displayName || a.name} <span className={"dot " + live} /></span><span className="pph-handle">@{a.name}</span></div>
           <button className="joinbtn pph-close" title={t("members.close")} onClick={onClose}><X size={14} /></button>
           {acts}
         </div>
-      ) : <div className="head head-agent"><div><h1>{a.displayName || a.name}</h1><small>@{a.name}</small></div>{acts}</div>}
+      ) : <div className="head head-agent"><Avatar seed={a.name} url={signedAvatar} size={48} /><div><h1>{a.displayName || a.name}</h1><small>@{a.name} <span className={"dot " + live} /></small></div>{acts}</div>}
       <div className="ptabs">
         {/* Tab order follows AgentDetailPanel spec: integrations (not apps) */}
         {([
@@ -187,6 +190,12 @@ export function AgentProfile({ id, onDeleted, onClose, onMessage }: { id: string
             <div className="card">
               {edit ? (
                 <div className="setform">
+                  <input type="file" ref={avFileRef} accept="image/*" style={{ display: "none" }} onChange={onPickAvatar} />
+                  <div className="avatar-edit">
+                    {signedAvatar ? <img className="avatar-edit-img" src={signedAvatar} alt="" /> : <Avatar seed={a.name} size={56} />}
+                    <div><button type="button" disabled={avBusy} onClick={() => avFileRef.current?.click()}>{avBusy ? t("misc.serverAvatarUploading") : signedAvatar ? t("misc.serverAvatarChange") : t("misc.serverAvatarUpload")}</button>
+                    {avErr && <div className="form-err" style={{ marginTop: 6 }}>{avErr}</div>}</div>
+                  </div>
                   <label>{t("members.displayName")}</label><input value={dn} onChange={(e) => setDn(e.target.value)} placeholder={a.name} />
                   <label>{t("members.agentDescriptionLabel")}</label><textarea value={ds} maxLength={3000} onChange={(e) => setDs(e.target.value)} placeholder={t("members.agentDescriptionPlaceholder")} />
                   <div className="ta-count">{ds.trim().length}/3000</div>
@@ -446,23 +455,34 @@ export function CreateAgentModal({ onClose, prefill, onCreated }: { onClose: () 
 // Description is visible to other humans and agents in the server; agents fetch it via `open-tag server info` for collaboration context.
 function HumanProfile({ uid }: { uid: string }) {
   const { t } = useTranslation();
-  const { api, serverId, me, reload, slug, capabilities } = useStore();
+  const { api, serverId, me, reload, slug, capabilities, uploadUserAvatar, attachmentUrl } = useStore();
   const confirm = useConfirm();
   const nav = useNavigate();
   const [p, setP] = useState<any>(null);
   const [edit, setEdit] = useState(false); const [ds, setDs] = useState("");
-  const refetch = async () => setP(await api("GET", `/api/servers/${serverId}/members/${uid}/profile`));
-  useEffect(() => { setP(null); refetch(); }, [uid, serverId]);
+  const [avBusy, setAvBusy] = useState(false); const [avErr, setAvErr] = useState(""); const [signedAvatar, setSignedAvatar] = useState<string | null>(null);
+  const avFileRef = useRef<HTMLInputElement>(null);
+  const refetch = async () => { const data = await api("GET", `/api/servers/${serverId}/members/${uid}/profile`); setP(data); setSignedAvatar(data?.avatarUrl ? attachmentUrl(data.avatarUrl.replace("/api/attachments/", "")) : null); };
+  useEffect(() => { setP(null); setSignedAvatar(null); refetch(); }, [uid, serverId]);
+  const onPickAvatar = async (e: any) => { const f = e.target.files?.[0]; e.target.value = ""; if (!f) return; setAvBusy(true); setAvErr(""); try { const url = await uploadUserAvatar(f); setSignedAvatar(url); await refetch(); await reload(); } catch (err: any) { setAvErr(String(err?.message || err)); } finally { setAvBusy(false); } };
   if (!p) return <div className="scroll"><div className="empty">{t("members.loading")}</div></div>;
   const isMe = me?.id === uid;
   const save = async () => { await api("PATCH", "/api/auth/me", { description: ds.trim() }); setEdit(false); await refetch(); await reload(); };
   return (
     <>
-      <div className="head"><h1 style={{ display: "flex", alignItems: "center", gap: 8 }}><Avatar seed={p.name} size={26} />{p.displayName || p.name}</h1><small>@{p.name} · {p.role}</small></div>
+      <div className="head"><h1 style={{ display: "flex", alignItems: "center", gap: 8 }}><Avatar seed={p.name} url={signedAvatar} size={26} />{p.displayName || p.name}</h1><small>@{p.name} · {p.role}</small></div>
+      <input type="file" ref={avFileRef} accept="image/*" style={{ display: "none" }} onChange={onPickAvatar} />
       <div className="scroll">
         <div className="card">
           {edit ? (
             <div className="setform">
+              {isMe && (
+                <div className="avatar-edit">
+                  {signedAvatar ? <img className="avatar-edit-img" src={signedAvatar} alt="" /> : <Avatar seed={p.name} size={56} />}
+                  <div><button type="button" disabled={avBusy} onClick={() => avFileRef.current?.click()}>{avBusy ? t("misc.serverAvatarUploading") : signedAvatar ? t("misc.serverAvatarChange") : t("misc.serverAvatarUpload")}</button>
+                  {avErr && <div className="form-err" style={{ marginTop: 6 }}>{avErr}</div>}</div>
+                </div>
+              )}
               <label>{t("members.humanDescriptionLabel")}</label>
               <textarea value={ds} maxLength={3000} onChange={(e) => setDs(e.target.value)} placeholder="Describe yourself for other humans and agents in this server" />
               <div className="ta-count">{ds.trim().length}/3000</div>


### PR DESCRIPTION
## Summary

- **修复 AgentProfile 全页 head 不显示头像**：之前 head 区域只有名字，现在加上了 Avatar 组件 + 在线状态点
- **支持 agent 头像上传**：新增 `POST /api/agents/:id/avatar` 端点（需要 `manageAgents` 权限）
- **支持 human 自身头像上传**：新增 `POST /api/auth/me/avatar` 端点，仅对 `isMe` 显示入口
- 头像存储走现有 attachments 系统，DB 存 `/api/attachments/<uuid>`，展示时附 token 签名
- 向后兼容：未上传自定义头像时继续回退到 DiceBear seed 头像

## Changed files

- `src/server/routes-api.ts` — 两个新 API 端点
- `web/src/Avatar.tsx` — 增加可选 `url` prop
- `web/src/store.tsx` — `uploadAgentAvatar` / `uploadUserAvatar` 方法暴露到 Context
- `web/src/views/Members.tsx` — AgentProfile + HumanProfile 头像展示与上传 UI

## Review checklist (per @Code-review master's flags)

- [ ] 上传路径权限校验：agent 头像需 `manageAgents`；`/api/auth/me/avatar` 用已认证的 `userId`
- [ ] 图片类型校验：服务端检查 `mimeType.startsWith("image/")`
- [ ] 大小限制：沿用 `parseUpload` 现有上限（与 server avatar 端点一致）
- [ ] 向后兼容：Avatar `url` prop 为可选，null/undefined 时回退 DiceBear

## Test plan

- 以 manageAgents 用户上传 agent 头像，确认 head + panel 均更新
- 普通 member 上传自身头像，确认个人 profile head 更新
- 无自定义头像的 agent/human 仍显示 DiceBear 头像
- 上传非图片文件确认被 400 拒绝