### PR TITLE
chore: bootstrap-only seed + prod daemon env + CLAUDE.md AGENTS pointer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # open-tag
 
+@AGENTS.md
+
 **Please read [`AGENTS.md`](./AGENTS.md)** — it is the canonical guide for working in
 this repo: a map of where things live, doc-sync discipline, code quality rules,
 parallel-worktree dev, and the verification bar. Kept as the single source of truth so

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -8,7 +8,7 @@
 - [x] Database schema (`src/db/schema.ts`: users/servers/serverMembers/machines/agents/channels/channelMembers/messages/messageMentions/reactions/attachments/reminders/knowledge)
 - [x] DB client (drizzle + postgres.js) `src/db/index.ts`; `db:push` migrations (13 tables created)
 - [x] Redis client + helpers: `seq:{serverId}` INCR, SSE pub/sub `src/redis.ts`
-- [x] Seed script: default `open-tag` workspace + you + #all + ada (executed)
+- [x] Bootstrap seed: default `open-tag` workspace + owner + #all only; machines and agents are created explicitly through onboarding
 
 ## P1 Control Plane (server ↔ daemon) — Verified end-to-end
 - [x] WS `/daemon/connect?key=` TS implementation + machine registration/heartbeat persistence + push to frontend (machine ready verified)

--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ npm run server
 npm run daemon
 ```
 
-Open **http://localhost:7777/s/open-tag/channel**, enter `#all`, and mention a seeded agent to run the full loop.
+Open **http://localhost:7777/s/open-tag/channel**. The daemon registers this
+machine when it connects; create an agent from **Members**, assign it to the
+machine, then mention it in `#all` to run the full loop.
 
 For frontend development with Vite HMR:
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "web:build": "npm --prefix web run build",
     "stop": "pkill -f 'src/server/index.ts'; pkill -f 'src/daemon/index.ts'; pkill -f 'bin/vite'; true",
     "start:prod": "ENV_FILE=.env.prod tsx src/server/index.ts",
-    "daemon:prod": "ENV_FILE=.env.prod tsx src/daemon/index.ts --api-key poc-secret-key",
+    "daemon:prod": "set -a && . ./.env.prod && set +a && ENV_FILE=.env.prod tsx src/daemon/index.ts --api-key \"$DAEMON_BOOTSTRAP_KEY\"",
     "db:push:prod": "set -a && . ./.env.prod && set +a && drizzle-kit push",
     "seed:prod": "ENV_FILE=.env.prod tsx src/db/seed.ts",
     "stop:prod": "lsof -ti tcp:7788 | xargs kill 2>/dev/null; true",

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -1,10 +1,11 @@
-// Initial seed data: one human (you) + the open-tag workspace + #all channel + one agent (ada)
+// Initial bootstrap data: one human (you) + the open-tag workspace + #all channel.
+// Machines and agents are created explicitly through onboarding, never as production fixtures.
 import "../env.js"; // must be first: loads .env / ENV_FILE (.env.prod) → DATABASE_URL, before the db connection (required when running seed standalone)
 import { db, schema, sql } from "./index.js";
 import { eq } from "drizzle-orm";
 
 async function main() {
-  const { users, servers, serverMembers, agents, channels, channelMembers } = schema;
+  const { users, servers, serverMembers, channels, channelMembers } = schema;
 
   // Idempotent, with a one-time migration for installs created before the default slug was renamed.
   const existing = await db.select().from(servers).where(eq(servers.slug, "open-tag"));
@@ -27,25 +28,17 @@ async function main() {
 
   await db.insert(serverMembers).values({ serverId: server!.id, userId: you!.id, role: "owner" });
 
-  const [ada] = await db.insert(agents).values({
-    serverId: server!.id, name: "ada", displayName: "Ada",
-    description: "Your local full-stack assistant, capable of reading and writing files and running commands in its own workspace.",
-    model: "sonnet", runtime: "claude",
-  }).returning();
-
   const [all] = await db.insert(channels).values({
     serverId: server!.id, name: "all", description: "Channel for all members", type: "channel",
   }).returning();
 
-  await db.insert(channelMembers).values([
-    { channelId: all!.id, memberType: "user", memberId: you!.id },
-    { channelId: all!.id, memberType: "agent", memberId: ada!.id },
-  ]);
+  await db.insert(channelMembers).values({
+    channelId: all!.id, memberType: "user", memberId: you!.id,
+  });
 
   console.log("[seed] done:");
   console.log("  server:", server!.id, "(slug=open-tag)");
   console.log("  user  :", you!.id, "(you)");
-  console.log("  agent :", ada!.id, "(ada)");
   console.log("  channel #all:", all!.id);
   await sql.end();
 }


### PR DESCRIPTION
Three small, independent WIP-polish changes that were sitting uncommitted, extracted onto a clean `origin/main` base.

## 1. Bootstrap-only seed
`npm run seed` no longer creates a demo `ada` agent — it seeds only the workspace, the owner, and `#all`. **Agents and machines are created explicitly through onboarding, never as production fixtures.**
- `src/db/seed.ts` — drop the seeded agent + its channel membership.
- `README.md` — quickstart now says "create an agent from **Members**, assign it to the machine, then mention it in `#all`".
- `FEATURES.md` — seed line updated to "Bootstrap seed: workspace + owner + #all only".

**Verified** against a throwaway DB: a fresh `seed` yields `servers=1, channels=1, agents=0` (no fixture agent).

## 2. prod daemon env sourcing
`package.json` — `daemon:prod` now `set -a && . ./.env.prod && set +a` and passes `$DAEMON_BOOTSTRAP_KEY` instead of a hard-coded `poc-secret-key`, so production uses the real bootstrap key.

## 3. CLAUDE.md pointer
Add the `@AGENTS.md` import line so the canonical guide is loaded.

## Validation
- `tsc --noEmit` (root) green.
- Real `seed` run on a fresh DB confirms bootstrap-only behaviour (agents=0).

> Excludes the in-progress mention auto-join work (its own worktree/branch) and the docker control plane (separate PR).
