### PR TITLE
feat(dev): per-worktree on-demand dev E2E harness (OPEN_TAG_HOME + dev:e2e + dev-bot)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,13 +36,34 @@ its own iterative improvement — autonomously.
 ## Parallel development (worktrees)
 
 - Use `npm run wt:add -- <name>` to spin up an isolated git worktree (its own ports +
-  `opentag_<name>` database + redis index + seeded data); `npm run wt:rm -- <name>`
-  tears it down. Lets several features (or agents) run side by side without port or
-  database collisions. (`vite.config` + `src/env.ts` already read `PORT` / `VITE_PORT` /
-  `ENV_FILE`, so each worktree is fully isolated.)
+  `opentag_<name>` database + redis index + **`OPEN_TAG_HOME=~/.open-tag-<name>` data dir** +
+  seeded data); `npm run wt:rm -- <name>` tears it down (and cleans the data dir + db). Lets
+  several features (or agents) run side by side without port, database, **or daemon/agent
+  workspace** collisions. wt:add branches each worktree from `origin/main` (not your current
+  HEAD), so PRs made from it never inherit an unrelated branch — set `WT_BASE=HEAD` to stack
+  on the current branch instead. (`vite.config` + `src/env.ts` read `PORT` / `VITE_PORT` /
+  `ENV_FILE`; `src/paths.ts` reads `OPEN_TAG_HOME` — so each worktree is fully isolated.)
 - Browser verification: check your own web UI with the chrome-devtools MCP. When several
   agents or worktrees run in parallel, start chrome-devtools with `--isolated` so each
   gets its own Chrome instance instead of fighting over a shared one.
+
+### Isolated dev E2E (on demand)
+
+When a task touches the **agent runtime / human↔agent loop / realtime delivery to agents /
+agent memory**, verify it in an isolated live stack instead of poking prod or hand-wiring
+JWTs:
+
+1. `npm run wt:add -- <task>` — isolated worktree (own DB, ports, redis, data dir).
+2. `cd ../open-tag-<task>` and do the work.
+3. `npm run dev:e2e:up` — builds web, starts server + daemon (background), seeds a real
+   `claude`/`sonnet` `@dev-bot` in `#all`, and prints the dev-login URL
+   `http://localhost:$PORT/?as=you` (the server serves the built web, so no separate vite).
+4. Verify (browser dev-login → `@dev-bot`, or curl).
+5. `npm run dev:e2e:down`, then from the main repo `npm run wt:rm -- <task>`.
+
+This needs the `claude` CLI installed + authenticated (it runs a real agent). If your task
+does **not** involve the agent runtime (docs, pure REST, UI-only), skip it — it's wasted
+setup otherwise. Decide per task.
 
 ## Doc-sync discipline (highest priority: code change = doc change)
 

--- a/docs/superpowers/plans/2026-06-24-dev-e2e-harness.md
+++ b/docs/superpowers/plans/2026-06-24-dev-e2e-harness.md
@@ -212,16 +212,31 @@ git commit -m "feat(seed): seed:dev — idempotent claude/sonnet dev-bot fixture
 
 ---
 
-## Task 3: wt:add / wt:rm per-worktree data-dir isolation + teardown
+## Task 3: wt:add / wt:rm — PR-clean base + per-worktree data-dir isolation + teardown
 
 **Files:**
-- Modify: `scripts/wt-add.sh` (the `.env` heredoc)
+- Modify: `scripts/wt-add.sh` (branch base + the `.env` heredoc)
 - Modify: `scripts/wt-rm.sh` (teardown)
 
 **Interfaces:**
-- Produces: each worktree `.env` now carries `OPEN_TAG_HOME=$HOME/.open-tag-<safe>` and `ALLOW_DEV_LOGIN=true`; `wt:rm` removes that data dir and drops the DB.
+- Produces: `wt:add` branches each new worktree from the latest `origin/main` (not the current HEAD), so PR diffs never inherit whatever branch you happened to be on; each worktree `.env` carries `OPEN_TAG_HOME=$HOME/.open-tag-<safe>` and `ALLOW_DEV_LOGIN=true`; `wt:rm` removes that data dir and drops the DB.
 
-- [ ] **Step 1: Extend the `wt-add.sh` `.env` heredoc**
+- [ ] **Step 1: Branch from `origin/main`, not the current HEAD (PR-clean base)**
+
+`wt-add.sh` currently runs `git worktree add "$WT" -b "feature/$NAME"` with **no base**, so the
+worktree branches from whatever HEAD you're on (e.g. `feat/docker-control-plane`), and any PR
+made from it would inherit that branch's content. Fetch and branch from the canonical main
+instead (with an opt-out for the rare "stack on current branch" case):
+
+```bash
+# replace:  git worktree add "$WT" -b "feature/$NAME"
+BASE="${WT_BASE:-origin/main}"
+git fetch origin main --quiet
+git worktree add "$WT" -b "feature/$NAME" "$BASE"
+echo "  (branched from $BASE — set WT_BASE=HEAD to stack on the current branch instead)"
+```
+
+- [ ] **Step 2: Extend the `wt-add.sh` `.env` heredoc**
 
 Add two lines to the generated `.env` (after `DAEMON_BOOTSTRAP_KEY=poc-secret-key`):
 ```bash
@@ -230,7 +245,7 @@ ALLOW_DEV_LOGIN=true
 ```
 (`$SAFE` is already computed in the script as the sanitized name.)
 
-- [ ] **Step 2: Extend `wt-rm.sh` teardown**
+- [ ] **Step 3: Extend `wt-rm.sh` teardown**
 
 After `git worktree remove "$WT" --force`, add (replacing the "kept / to clean up" notice with real cleanup):
 ```bash
@@ -240,17 +255,18 @@ docker compose exec -T postgres dropdb -U opentag "opentag_$SAFE" 2>/dev/null &&
 echo "  branch feature/$NAME kept — remove with: git branch -D feature/$NAME"
 ```
 
-- [ ] **Step 3: Verify**
+- [ ] **Step 4: Verify**
 
 ```bash
 npm run wt:add -- e2etmp
+git -C ../open-tag-e2etmp merge-base --is-ancestor origin/main HEAD && echo "branched from origin/main ✓"  # base is current main
 grep -E "OPEN_TAG_HOME|ALLOW_DEV_LOGIN" ../open-tag-e2etmp/.env   # both present
 npm run wt:rm -- e2etmp                                            # removes worktree + data dir + db
 ls -d ~/.open-tag-e2etmp 2>/dev/null || echo "data dir gone ✓"
 ```
-Expected: `.env` has both lines; after `wt:rm`, the worktree, `~/.open-tag-e2etmp`, and `opentag_e2etmp` are gone.
+Expected: worktree branched from `origin/main`; `.env` has both lines; after `wt:rm`, the worktree, `~/.open-tag-e2etmp`, and `opentag_e2etmp` are gone.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
 git add scripts/wt-add.sh scripts/wt-rm.sh

--- a/docs/superpowers/plans/2026-06-24-dev-e2e-harness.md
+++ b/docs/superpowers/plans/2026-06-24-dev-e2e-harness.md
@@ -1,0 +1,431 @@
+# Per-worktree on-demand dev E2E harness — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a developer or coding agent bring up, on demand, a fully isolated workspace with a real runnable `claude`/`sonnet` agent for end-to-end human↔agent verification, with zero collision across parallel worktrees.
+
+**Architecture:** Build on the existing `wt:add` (which already isolates DB + ports + redis + `.env`). Add a single `OPEN_TAG_HOME` env so the daemon/agent data dir is per-worktree; an idempotent `seed:dev` that ensures a `claude`/`sonnet` agent; and on-demand `dev:e2e:up`/`:down` scripts that start server+daemon and verify readiness. AGENTS.md tells the coding agent when to use it.
+
+**Tech Stack:** TypeScript (Node 20+, tsx), drizzle-orm + postgres, bash scripts, socket.io, `node:test`.
+
+## Global Constraints
+
+- Default behavior unchanged: with no `OPEN_TAG_HOME` set, every path resolves to `~/.open-tag/...` exactly as today (prod/existing setups unaffected).
+- `seed:dev` is a DEV-ONLY fixture; it must never run on production paths and must be idempotent.
+- Single source of truth for paths: `src/paths.ts`. Existing `OPEN_TAG_LOG_DIR` / `OPEN_TAG_UPLOAD_DIR` overrides keep working and take precedence over the `OPEN_TAG_HOME`-derived default.
+- Invocation is plain `npm run` scripts (agent-agnostic), never auto-triggered.
+- `claude` CLI + credentials are assumed present on the dev host; absence must fail loud, never seed a dead agent silently.
+
+---
+
+## File Structure
+
+- Create `src/paths.ts` — resolves `OPEN_TAG_HOME` and all derived dirs (one responsibility: path resolution).
+- Create `test/paths.unit.test.ts` — unit tests for path resolution (default + override).
+- Modify `src/daemon/agentManager.ts`, `src/daemon/workspace.ts`, `src/daemon/openTagBin.ts`, `src/daemon/index.ts`, `src/log.ts`, `src/server/storage.ts` — source dirs from `src/paths.ts`.
+- Create `src/db/seed-dev.ts` — idempotent dev agent fixture.
+- Create `scripts/dev-e2e-up.sh`, `scripts/dev-e2e-down.sh` — on-demand stack lifecycle.
+- Modify `scripts/wt-add.sh`, `scripts/wt-rm.sh` — per-worktree data-dir isolation + teardown.
+- Modify `package.json` — add `seed:dev`, `dev:e2e:up`, `dev:e2e:down`.
+- Modify `AGENTS.md` — dev E2E guidance.
+
+---
+
+## Task 1: `OPEN_TAG_HOME` path module + wire all consumers
+
+**Files:**
+- Create: `src/paths.ts`
+- Test: `test/paths.unit.test.ts`
+- Modify: `src/daemon/agentManager.ts:11-12`, `src/daemon/workspace.ts:8`, `src/daemon/openTagBin.ts:9`, `src/daemon/index.ts:31`, `src/log.ts:7`, `src/server/storage.ts:12`
+
+**Interfaces:**
+- Produces: `openTagHome(): string`, `agentsDir(): string`, `binDir(): string`, `machineIdFile(): string`, `logsDir(): string`, `uploadsDir(): string` — all read `process.env` on each call so env loaded via `env.ts` before first call is honored, and tests can toggle env between calls.
+
+- [ ] **Step 1: Write the failing test** — `test/paths.unit.test.ts`
+
+```ts
+// Run: npx tsx --test --test-force-exit test/paths.unit.test.ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import * as p from "../src/paths.ts";
+
+test("defaults to ~/.open-tag when OPEN_TAG_HOME is unset", () => {
+  delete process.env.OPEN_TAG_HOME;
+  delete process.env.OPEN_TAG_LOG_DIR;
+  delete process.env.OPEN_TAG_UPLOAD_DIR;
+  const home = path.join(os.homedir(), ".open-tag");
+  assert.equal(p.openTagHome(), home);
+  assert.equal(p.agentsDir(), path.join(home, "agents"));
+  assert.equal(p.binDir(), path.join(home, "bin"));
+  assert.equal(p.machineIdFile(), path.join(home, "machine-id"));
+  assert.equal(p.logsDir(), path.join(home, "logs"));
+  assert.equal(p.uploadsDir(), path.join(home, "uploads"));
+});
+
+test("OPEN_TAG_HOME relocates every derived dir", () => {
+  process.env.OPEN_TAG_HOME = "/tmp/ot-wtX";
+  delete process.env.OPEN_TAG_LOG_DIR;
+  delete process.env.OPEN_TAG_UPLOAD_DIR;
+  assert.equal(p.agentsDir(), "/tmp/ot-wtX/agents");
+  assert.equal(p.binDir(), "/tmp/ot-wtX/bin");
+  assert.equal(p.machineIdFile(), "/tmp/ot-wtX/machine-id");
+  assert.equal(p.logsDir(), "/tmp/ot-wtX/logs");
+  assert.equal(p.uploadsDir(), "/tmp/ot-wtX/uploads");
+});
+
+test("legacy OPEN_TAG_LOG_DIR / OPEN_TAG_UPLOAD_DIR still win", () => {
+  process.env.OPEN_TAG_HOME = "/tmp/ot-wtX";
+  process.env.OPEN_TAG_LOG_DIR = "/var/log/ot";
+  process.env.OPEN_TAG_UPLOAD_DIR = "/var/up/ot";
+  assert.equal(p.logsDir(), "/var/log/ot");
+  assert.equal(p.uploadsDir(), "/var/up/ot");
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx tsx --test --test-force-exit test/paths.unit.test.ts`
+Expected: FAIL — cannot find module `../src/paths.ts`.
+
+- [ ] **Step 3: Create `src/paths.ts`**
+
+```ts
+// Single source of truth for on-disk locations. OPEN_TAG_HOME (default ~/.open-tag) lets each
+// worktree/dev environment use its own data dir so parallel daemons/agents never collide.
+// Read on each call so env loaded by env.ts (before first use) is honored, and tests can toggle it.
+import os from "node:os";
+import path from "node:path";
+
+export const openTagHome = (): string => process.env.OPEN_TAG_HOME ?? path.join(os.homedir(), ".open-tag");
+export const agentsDir = (): string => path.join(openTagHome(), "agents");
+export const binDir = (): string => path.join(openTagHome(), "bin");
+export const machineIdFile = (): string => path.join(openTagHome(), "machine-id");
+// Legacy specific overrides keep precedence over the HOME-derived default (back-compat).
+export const logsDir = (): string => process.env.OPEN_TAG_LOG_DIR ?? path.join(openTagHome(), "logs");
+export const uploadsDir = (): string => process.env.OPEN_TAG_UPLOAD_DIR ?? path.join(openTagHome(), "uploads");
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx tsx --test --test-force-exit test/paths.unit.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Wire the six consumers**
+
+`src/daemon/agentManager.ts` — replace the hardcoded `DATA_DIR`:
+```ts
+// remove: const DATA_DIR = path.join(os.homedir(), ".open-tag", "agents");
+import { agentsDir } from "../paths.js";
+const DATA_DIR = agentsDir();
+```
+`src/daemon/workspace.ts` — same:
+```ts
+// remove: const DATA_DIR = path.join(os.homedir(), ".open-tag", "agents");
+import { agentsDir } from "../paths.js";
+const DATA_DIR = agentsDir();
+```
+`src/daemon/openTagBin.ts` — replace `path.join(os.homedir(), ".open-tag", "bin")` with `binDir()` (add `import { binDir } from "../paths.js";`).
+`src/daemon/index.ts` — replace `const MID_FILE = path.join(os.homedir(), ".open-tag", "machine-id");` with `import { machineIdFile } from "../paths.js"; const MID_FILE = machineIdFile();`.
+`src/log.ts` — replace `const LOG_DIR = process.env.OPEN_TAG_LOG_DIR ?? path.join(os.homedir(), ".open-tag", "logs");` with `import { logsDir } from "./paths.js"; const LOG_DIR = logsDir();`.
+`src/server/storage.ts` — replace `const LOCAL_DIR = process.env.OPEN_TAG_UPLOAD_DIR ?? path.join(os.homedir(), ".open-tag", "uploads");` with `import { uploadsDir } from "../paths.js"; const LOCAL_DIR = uploadsDir();`.
+
+Remove now-unused `os`/`path` imports only if they become unused (check each file; several still use `path`/`os` elsewhere — leave those).
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npx tsc --noEmit` → Expected: exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/paths.ts test/paths.unit.test.ts src/daemon/agentManager.ts src/daemon/workspace.ts src/daemon/openTagBin.ts src/daemon/index.ts src/log.ts src/server/storage.ts
+git commit -m "feat(paths): OPEN_TAG_HOME so daemon/agent data dir is per-worktree isolatable"
+```
+
+---
+
+## Task 2: `seed:dev` dev agent fixture
+
+**Files:**
+- Create: `src/db/seed-dev.ts`
+- Modify: `package.json` (scripts)
+
+**Interfaces:**
+- Consumes: `schema` from `src/db/index.ts`; the `open-tag` workspace + `#all` channel created by `npm run seed`.
+- Produces: an agent row `name="dev-bot"`, `runtime="claude"`, `model="sonnet"` in the `open-tag` server, joined to `#all`. Idempotent (skip if present).
+
+- [ ] **Step 1: Create `src/db/seed-dev.ts`**
+
+```ts
+// DEV-ONLY fixture: ensure a runnable claude/sonnet agent ("dev-bot") exists in the open-tag
+// workspace + #all, for local human↔agent E2E. Idempotent. Never run on production paths.
+import "../env.js";
+import { db, schema, sql } from "./index.js";
+import { and, eq } from "drizzle-orm";
+
+async function main() {
+  const { servers, agents, channels, channelMembers } = schema;
+  const [server] = await db.select().from(servers).where(eq(servers.slug, "open-tag"));
+  if (!server) { console.error("[seed:dev] no 'open-tag' workspace — run `npm run seed` first"); await sql.end(); process.exit(1); }
+
+  const existing = await db.select().from(agents).where(and(eq(agents.serverId, server.id), eq(agents.name, "dev-bot")));
+  if (existing.length && !existing[0]!.deletedAt) { console.log("[seed:dev] dev-bot already exists, skipping"); await sql.end(); return; }
+
+  const [bot] = await db.insert(agents).values({
+    serverId: server.id, name: "dev-bot", displayName: "Dev Bot",
+    description: "Local dev E2E agent — claude/sonnet. Created by `npm run seed:dev`.",
+    model: "sonnet", runtime: "claude",
+  }).returning();
+
+  const [all] = await db.select().from(channels).where(and(eq(channels.serverId, server.id), eq(channels.name, "all")));
+  if (all) await db.insert(channelMembers).values({ channelId: all.id, memberType: "agent", memberId: bot!.id }).onConflictDoNothing();
+
+  console.log(`[seed:dev] created dev-bot (${bot!.id}) in #all`);
+  await sql.end();
+}
+main().catch((e) => { console.error(e); process.exit(1); });
+```
+
+- [ ] **Step 2: Add npm scripts** — `package.json`, in `"scripts"`:
+
+```json
+"seed:dev": "tsx src/db/seed-dev.ts",
+```
+
+- [ ] **Step 3: Verify against a scratch DB (integration)**
+
+Run (from a worktree whose `.env` points at its own DB, after `npm run db:push && npm run seed`):
+```bash
+npm run seed:dev          # → "created dev-bot (...) in #all"
+npm run seed:dev          # → "dev-bot already exists, skipping"  (idempotent)
+```
+Expected: first run creates, second run is a no-op.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/db/seed-dev.ts package.json
+git commit -m "feat(seed): seed:dev — idempotent claude/sonnet dev-bot fixture for E2E"
+```
+
+---
+
+## Task 3: wt:add / wt:rm per-worktree data-dir isolation + teardown
+
+**Files:**
+- Modify: `scripts/wt-add.sh` (the `.env` heredoc)
+- Modify: `scripts/wt-rm.sh` (teardown)
+
+**Interfaces:**
+- Produces: each worktree `.env` now carries `OPEN_TAG_HOME=$HOME/.open-tag-<safe>` and `ALLOW_DEV_LOGIN=true`; `wt:rm` removes that data dir and drops the DB.
+
+- [ ] **Step 1: Extend the `wt-add.sh` `.env` heredoc**
+
+Add two lines to the generated `.env` (after `DAEMON_BOOTSTRAP_KEY=poc-secret-key`):
+```bash
+OPEN_TAG_HOME=$HOME/.open-tag-$SAFE
+ALLOW_DEV_LOGIN=true
+```
+(`$SAFE` is already computed in the script as the sanitized name.)
+
+- [ ] **Step 2: Extend `wt-rm.sh` teardown**
+
+After `git worktree remove "$WT" --force`, add (replacing the "kept / to clean up" notice with real cleanup):
+```bash
+SAFE="${NAME//[^a-zA-Z0-9]/_}"
+rm -rf "$HOME/.open-tag-$SAFE" && echo "  removed data dir ~/.open-tag-$SAFE"
+docker compose exec -T postgres dropdb -U opentag "opentag_$SAFE" 2>/dev/null && echo "  dropped db opentag_$SAFE" || echo "  (db opentag_$SAFE not found / already dropped)"
+echo "  branch feature/$NAME kept — remove with: git branch -D feature/$NAME"
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+npm run wt:add -- e2etmp
+grep -E "OPEN_TAG_HOME|ALLOW_DEV_LOGIN" ../open-tag-e2etmp/.env   # both present
+npm run wt:rm -- e2etmp                                            # removes worktree + data dir + db
+ls -d ~/.open-tag-e2etmp 2>/dev/null || echo "data dir gone ✓"
+```
+Expected: `.env` has both lines; after `wt:rm`, the worktree, `~/.open-tag-e2etmp`, and `opentag_e2etmp` are gone.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/wt-add.sh scripts/wt-rm.sh
+git commit -m "feat(wt): per-worktree OPEN_TAG_HOME + dev-login; wt:rm cleans data dir + db"
+```
+
+---
+
+## Task 4: on-demand `dev:e2e:up` / `dev:e2e:down`
+
+**Files:**
+- Create: `scripts/dev-e2e-up.sh`, `scripts/dev-e2e-down.sh`
+- Modify: `package.json` (scripts)
+
+**Interfaces:**
+- Consumes: the current worktree `.env` (PORT, DATABASE_URL, OPEN_TAG_HOME, DAEMON_BOOTSTRAP_KEY); `npm run seed`, `npm run seed:dev`, `npm run build --prefix web`.
+- Produces: background `server` + `daemon` for this worktree, a registered online machine, a seeded `dev-bot`; prints the dev-login URL.
+
+- [ ] **Step 1: Create `scripts/dev-e2e-up.sh`**
+
+```bash
+#!/usr/bin/env bash
+# Bring up an isolated, on-demand dev E2E stack for THIS worktree: server + daemon + dev-bot agent.
+# Server serves the built web/dist on PORT, so no separate vite process is needed for browser E2E.
+# Usage: npm run dev:e2e:up
+set -euo pipefail
+[ -f .env ] || { echo "✗ no .env in $(pwd) — run from a worktree created by 'npm run wt:add'"; exit 1; }
+PORT=$(grep -E "^PORT=" .env | cut -d= -f2)
+KEY=$(grep -E "^DAEMON_BOOTSTRAP_KEY=" .env | cut -d= -f2)
+HOME_DIR=$(grep -E "^OPEN_TAG_HOME=" .env | cut -d= -f2 | sed "s|\$HOME|$HOME|; s|^~|$HOME|")
+: "${PORT:?PORT missing in .env}" "${KEY:?DAEMON_BOOTSTRAP_KEY missing in .env}"
+command -v claude >/dev/null 2>&1 || { echo "✗ 'claude' CLI not found on PATH — install + authenticate it before dev:e2e (agents won't run otherwise)"; exit 1; }
+mkdir -p "${HOME_DIR:-$HOME/.open-tag}/logs"
+RUN="${HOME_DIR:-$HOME/.open-tag}"
+
+echo "→ schema + seed (idempotent)…"
+npm run db:push >/dev/null 2>&1 || true
+npm run seed    >/dev/null 2>&1 || true
+
+echo "→ building web (served by server on $PORT)…"
+npm run build --prefix web >/dev/null
+
+echo "→ starting server (:$PORT) + daemon…"
+nohup npx tsx src/server/index.ts   > "$RUN/logs/dev-e2e-server.log" 2>&1 & echo $! > "$RUN/dev-e2e-server.pid"
+# wait for server health
+for i in $(seq 1 30); do curl -sf "http://localhost:$PORT/" >/dev/null 2>&1 && break; sleep 1; done
+nohup npx tsx src/daemon/index.ts --api-key "$KEY" > "$RUN/logs/dev-e2e-daemon.log" 2>&1 & echo $! > "$RUN/dev-e2e-daemon.pid"
+# wait for the daemon to register (machine-id file written by the daemon under OPEN_TAG_HOME)
+for i in $(seq 1 30); do [ -s "$RUN/machine-id" ] && break; sleep 1; done
+
+echo "→ seeding dev-bot…"; npm run seed:dev || true
+
+cat <<EOF
+
+✅ dev E2E up (worktree-isolated)
+   data dir : $RUN
+   login    : http://localhost:$PORT/?as=you
+   agent    : @dev-bot  (claude/sonnet) in #all
+   logs     : $RUN/logs/dev-e2e-{server,daemon}.log
+   stop     : npm run dev:e2e:down
+EOF
+```
+
+- [ ] **Step 2: Create `scripts/dev-e2e-down.sh`**
+
+```bash
+#!/usr/bin/env bash
+# Stop this worktree's dev E2E stack (server + daemon started by dev:e2e:up).
+set -euo pipefail
+[ -f .env ] || { echo "✗ no .env in $(pwd)"; exit 1; }
+HOME_DIR=$(grep -E "^OPEN_TAG_HOME=" .env | cut -d= -f2 | sed "s|\$HOME|$HOME|; s|^~|$HOME|")
+RUN="${HOME_DIR:-$HOME/.open-tag}"
+for svc in server daemon; do
+  f="$RUN/dev-e2e-$svc.pid"
+  if [ -f "$f" ]; then kill "$(cat "$f")" 2>/dev/null && echo "  stopped $svc ($(cat "$f"))" || echo "  $svc not running"; rm -f "$f"; fi
+done
+echo "✅ dev E2E down"
+```
+
+- [ ] **Step 3: Add npm scripts** — `package.json`:
+
+```json
+"dev:e2e:up": "bash scripts/dev-e2e-up.sh",
+"dev:e2e:down": "bash scripts/dev-e2e-down.sh",
+```
+
+- [ ] **Step 4: Verify (single worktree)**
+
+```bash
+# inside ../open-tag-e2etmp (from wt:add):
+npm run dev:e2e:up     # → server+daemon up, machine-id written, dev-bot seeded, prints login URL
+curl -sf http://localhost:$(grep ^PORT= .env|cut -d= -f2)/ >/dev/null && echo "server serving ✓"
+test -s ~/.open-tag-e2etmp/machine-id && echo "daemon registered ✓"
+npm run dev:e2e:down   # → stops both
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/dev-e2e-up.sh scripts/dev-e2e-down.sh package.json
+git commit -m "feat(dev): on-demand dev:e2e:up/down — isolated server+daemon+dev-bot stack"
+```
+
+---
+
+## Task 5: AGENTS.md guidance + full integration verification
+
+**Files:**
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: Add an AGENTS.md subsection** (under the verification/dev section)
+
+```markdown
+### Isolated dev E2E (on demand)
+
+When a task touches the **agent runtime / human↔agent loop / realtime delivery to agents /
+agent memory**, verify it in an isolated stack instead of poking prod:
+
+1. `npm run wt:add -- <task>` — isolated worktree: own DB, ports, redis, and **data dir**
+   (`~/.open-tag-<task>`), so parallel worktrees never collide.
+2. `cd ../open-tag-<task>` and do the work.
+3. `npm run dev:e2e:up` — builds web, starts server + daemon (background), seeds a real
+   `claude`/`sonnet` `@dev-bot` in `#all`, prints the dev-login URL `http://localhost:$PORT/?as=you`.
+4. Verify (browser dev-login → `@dev-bot`; or curl).
+5. `npm run dev:e2e:down`, then from the main repo `npm run wt:rm -- <task>` (removes worktree
+   + data dir + DB).
+
+If your task does NOT involve the agent runtime (docs, pure REST, UI-only), skip this — it
+needs the `claude` CLI/credentials and is wasted setup otherwise.
+```
+
+- [ ] **Step 2: Integration verification — parallel isolation (the headline)**
+
+```bash
+npm run wt:add -- e2ea
+npm run wt:add -- e2eb
+( cd ../open-tag-e2ea && npm run dev:e2e:up )
+( cd ../open-tag-e2eb && npm run dev:e2e:up )
+# assert two independent data dirs, two machine-ids, two servers:
+diff <(cat ~/.open-tag-e2ea/machine-id) <(cat ~/.open-tag-e2eb/machine-id) && echo "FAIL: shared machine-id" || echo "isolated machine-id ✓"
+ls ~/.open-tag-e2ea/agents ~/.open-tag-e2eb/agents   # separate agent workspaces
+```
+Expected: different machine-ids, separate agent dirs, both servers healthy on their own ports.
+
+- [ ] **Step 3: Integration verification — full human↔agent E2E**
+
+In `../open-tag-e2ea`, open `http://localhost:$PORT/?as=you` (chrome-devtools), go to `#all`,
+send `@dev-bot ping — reply with the word pong`, and confirm a real `claude` reply lands in
+the channel live (no refresh). Capture the reply text as evidence.
+
+- [ ] **Step 4: Teardown + typecheck**
+
+```bash
+( cd ../open-tag-e2ea && npm run dev:e2e:down )
+( cd ../open-tag-e2eb && npm run dev:e2e:down )
+npm run wt:rm -- e2ea
+npm run wt:rm -- e2eb
+npx tsc --noEmit          # exit 0
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add AGENTS.md
+git commit -m "docs(agents): guidance for on-demand isolated dev E2E harness"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** real runnable agent (Task 2 + 4 + 5.3), DB isolation (existing wt:add, unchanged), local runtime (daemon on host, Task 4), on-demand (Task 4 + AGENTS.md Task 5), per-worktree parallel (Task 1 OPEN_TAG_HOME + Task 3 + verified Task 5.2). All covered.
+
+**Placeholder scan:** none — every step has concrete code/commands.
+
+**Type consistency:** `paths.ts` exports (`openTagHome/agentsDir/binDir/machineIdFile/logsDir/uploadsDir`) match consumer usage in Task 1 Step 5. `seed-dev.ts` agent name `dev-bot` matches AGENTS.md + verification references.
+
+**Assumption to re-confirm at execution:** `dev-e2e-up.sh` derives `OPEN_TAG_HOME` from `.env` and `claude` must be on PATH — both fail loud if missing.

--- a/docs/superpowers/specs/2026-06-24-dev-e2e-harness-design.md
+++ b/docs/superpowers/specs/2026-06-24-dev-e2e-harness-design.md
@@ -1,0 +1,155 @@
+# Per-worktree on-demand dev E2E harness
+
+Date: 2026-06-24
+Status: approved design (pending spec review)
+
+## Problem
+
+There is no isolated, repeatable way to run a **full human↔agent end-to-end** loop
+locally. Verifying anything that touches the agent runtime (mention an agent → it runs →
+replies; realtime delivery to agents; memory; profile sync) today means hand-signing
+JWTs, manually creating channels, and there is no ready-to-run agent bound to the local
+daemon. Multiple developers/agents working in parallel also risk colliding on the shared
+`~/.open-tag` data dir and the single database.
+
+## Goal
+
+A developer or coding agent can, **on demand**, bring up a fully isolated workspace with a
+**real runnable `claudecode`/`sonnet` agent** and drive the complete human↔agent loop —
+without disturbing production, other worktrees, or other developers.
+
+## Requirements (from brainstorm)
+
+1. **Real runnable agent** — full E2E: dev-login in the browser, `@` the seeded agent in a
+   channel, it actually runs on the local `claude` runtime and replies.
+2. **Database isolation** — per worktree, separate database.
+3. **Local runtime** — `claude` runs on the host (daemon on host, not in a container).
+4. **On-demand** — not always-on. The coding agent decides per task whether to spin it up;
+   tasks that don't touch the agent runtime skip it.
+5. **Per-worktree isolation, fully parallel** — each worktree gets its own DB + ports +
+   data dir; two worktrees run server+daemon+agent simultaneously with zero collision.
+
+## What already exists (build on, don't rebuild)
+
+`scripts/wt-add.sh` (`npm run wt:add -- <name>`) already provisions most isolation: own
+branch, free ports (server from 7801, vite from 5301), a separate database
+`opentag_<name>`, a separate redis DB index, a generated worktree `.env`, deps install,
+schema push, and seed. `src/env.ts` loads the worktree `.env` for **both** the server and
+the daemon entry points (both `import "../env.js"`), and the daemon defaults its
+`--server-url` to `http://localhost:${PORT}` from that `.env`. `log.ts` and `storage.ts`
+already support env overrides (`OPEN_TAG_LOG_DIR`, `OPEN_TAG_UPLOAD_DIR`) — a precedent.
+
+The **only** isolation gap is the daemon/agent data directory, which is hardcoded.
+
+## Approach (chosen): fill the gaps in wt:add + add an on-demand `dev:e2e`
+
+### Component 1 — `OPEN_TAG_HOME` env (the one code change)
+
+`~/.open-tag/{agents,bin,machine-id}` is hardcoded in four daemon files, so two worktrees'
+daemons would share agent workspaces and the machine-id. Introduce a single base dir:
+
+```
+OPEN_TAG_HOME = process.env.OPEN_TAG_HOME ?? path.join(os.homedir(), ".open-tag")
+```
+
+exported from one small module (e.g. `src/paths.ts`). Derive every subdir from it:
+- `src/daemon/agentManager.ts` — `DATA_DIR = <HOME>/agents`
+- `src/daemon/workspace.ts` — `DATA_DIR = <HOME>/agents`
+- `src/daemon/openTagBin.ts` — `<HOME>/bin`
+- `src/daemon/index.ts` — `MID_FILE = <HOME>/machine-id`
+- `src/log.ts` — default `<HOME>/logs` (keep `OPEN_TAG_LOG_DIR` as a higher-precedence override)
+- `src/server/storage.ts` — default `<HOME>/uploads` (keep `OPEN_TAG_UPLOAD_DIR` override)
+
+Default unchanged (`~/.open-tag`), so prod and existing setups are unaffected. Both entry
+points already load `.env`, so setting `OPEN_TAG_HOME` in a worktree `.env` is sufficient.
+
+### Component 2 — wt:add / wt:rm extension
+
+- `wt-add.sh`: add `OPEN_TAG_HOME=$HOME/.open-tag-<name>` and `ALLOW_DEV_LOGIN=true` to the
+  generated `.env`. Now each worktree is fully isolated: DB + ports + redis + **data dir**.
+- `wt-rm.sh`: on removal, also `rm -rf $HOME/.open-tag-<name>` and drop the `opentag_<name>`
+  database (verify current wt-rm behavior and extend as needed). No orphans.
+
+### Component 3 — `seed:dev` (dev-only fixture)
+
+New `npm run seed:dev` → `src/db/seed-dev.ts`. Idempotent. On top of the minimal bootstrap
+seed, create one agent in the dev workspace: `runtime: "claude"`, `model: "sonnet"`, a
+clear dev name (e.g. `dev-bot`), added to `#all`. Never invoked by production paths — this
+is explicitly a dev fixture (aligns with the bootstrap seed's "agents created through
+onboarding, never as production fixtures"). Login is already covered by dev-login (`?as=`).
+
+### Component 4 — on-demand `dev:e2e:up` / `dev:e2e:down`
+
+New scripts (`scripts/dev-e2e-up.sh` / `dev-e2e-down.sh`, exposed as `npm run dev:e2e:up` /
+`dev:e2e:down`):
+- **up**: build the web frontend if `web/dist` is stale, then start `server` and `daemon`
+  as background processes for the current worktree's `.env` (logs to the worktree's
+  `OPEN_TAG_HOME/logs`). The server serves the built `web/dist` on `PORT`, so the browser
+  E2E needs **no separate vite process** (vite HMR remains the path for active frontend
+  dev, unchanged). Poll until the server is healthy and the daemon's machine is
+  registered/online; run `seed:dev` (idempotent) so the agent exists; print the dev-login
+  URL `http://localhost:$PORT/?as=you` and the agent handle. Fail loud if the `claude`
+  CLI/credentials are missing.
+- **down**: stop the background server + daemon for this worktree.
+
+These are the **on-demand** entry point: a coding agent runs `dev:e2e:up` only when its task
+needs the live agent loop.
+
+### Component 5 — AGENTS.md guidance
+
+A short subsection: when a task touches the **agent runtime / human↔agent loop / realtime
+delivery to agents / agent memory**, spin up the isolated stack with `npm run dev:e2e:up`
+(per-worktree: separate DB + data dir + a real `claude`/`sonnet` agent), verify, then
+`npm run dev:e2e:down`. Otherwise skip it. This is what lets the coding agent decide
+autonomously — the trigger is documentation, not automation.
+
+## Data flow (the dev loop)
+
+```
+npm run wt:add -- foo
+  → ../open-tag-foo  +  .env { PORT, VITE_PORT, DATABASE_URL=opentag_foo,
+                                REDIS_URL, OPEN_TAG_HOME=~/.open-tag-foo, ALLOW_DEV_LOGIN }
+cd ../open-tag-foo  (do the code work)
+npm run dev:e2e:up
+  → server (PORT) + daemon → daemon registers machine, writes ~/.open-tag-foo/machine-id,
+    agent workspaces under ~/.open-tag-foo/agents/  (zero collision with other worktrees)
+  → seed:dev → claude/sonnet agent in #all
+browser http://localhost:$PORT/?as=you (server serves built web/dist) → @dev-bot
+  → real claude reply   ← full E2E
+npm run dev:e2e:down            (stop the live stack)
+npm run wt:rm -- foo            (from main repo: tears down worktree + DB + data dir)
+```
+
+## Invocation model
+
+Plain **npm scripts** run via Bash — agent-agnostic (works for Claude Code, Codex, humans),
+lives in the repo. **Not** a Claude Code slash command. **Never auto-triggered**; always
+explicit. The coding agent decides per task via AGENTS.md guidance. (An optional thin
+Claude-side `/dev-e2e` wrapper could exist later, but the npm script is the source of truth.)
+
+## Assumptions
+
+- The dev host has the `claude` CLI installed and authenticated (the team already uses it).
+  If absent, `dev:e2e:up` fails loud with a clear message rather than seeding a dead agent.
+- The shared docker postgres (5433) and redis (6380) from `docker compose` are running
+  (wt:add already relies on this).
+
+## Verification plan
+
+1. **Isolation (unit-ish)**: with `OPEN_TAG_HOME` set, the daemon resolves all paths under
+   it (assert via a small script or log inspection).
+2. **Parallel (the headline)**: `wt:add a` + `wt:add b`, `dev:e2e:up` in both → two servers,
+   two daemons, two machines, two agent workspaces under `~/.open-tag-a` vs `~/.open-tag-b`,
+   no shared files; a message in A's workspace never appears in B.
+3. **Full E2E**: in one worktree, browser dev-login → `@dev-bot` in #all → confirm a real
+   `claude` reply lands in the channel (chrome-devtools).
+4. **Teardown**: `dev:e2e:down` stops processes; `wt:rm` removes worktree + DB + data dir,
+   leaving no orphans.
+5. `npm run typecheck` green.
+
+## Out of scope (YAGNI)
+
+- Containerizing the daemon (conflicts with the local-runtime requirement).
+- Multiple seeded agents / extra channels (one agent + #all is enough; revisit if needed).
+- CI integration of the E2E harness (separate concern).
+- A Claude Code slash-command wrapper (optional future thin layer).

--- a/docs/superpowers/specs/2026-06-24-dev-e2e-harness-design.md
+++ b/docs/superpowers/specs/2026-06-24-dev-e2e-harness-design.md
@@ -65,8 +65,12 @@ points already load `.env`, so setting `OPEN_TAG_HOME` in a worktree `.env` is s
 
 ### Component 2 — wt:add / wt:rm extension
 
-- `wt-add.sh`: add `OPEN_TAG_HOME=$HOME/.open-tag-<name>` and `ALLOW_DEV_LOGIN=true` to the
-  generated `.env`. Now each worktree is fully isolated: DB + ports + redis + **data dir**.
+- `wt-add.sh`: **branch from the latest `origin/main`, not the current HEAD.** Today it runs
+  `git worktree add -b feature/<name>` with no base, so a worktree inherits whatever branch
+  you're on (e.g. `feat/docker-control-plane`) and any PR from it would carry that branch's
+  content. Fetch + branch from `origin/main` (env `WT_BASE` opt-out for stacking).
+- `wt-add.sh`: also add `OPEN_TAG_HOME=$HOME/.open-tag-<name>` and `ALLOW_DEV_LOGIN=true` to
+  the generated `.env`. Now each worktree is fully isolated: DB + ports + redis + **data dir**.
 - `wt-rm.sh`: on removal, also `rm -rf $HOME/.open-tag-<name>` and drop the `opentag_<name>`
   database (verify current wt-rm behavior and extend as needed). No orphans.
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "seed": "tsx src/db/seed.ts",
+    "seed:dev": "tsx src/db/seed-dev.ts",
     "server": "tsx watch src/server/index.ts",
     "start": "tsx src/server/index.ts",
     "web:build": "npm --prefix web run build",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "cli": "tsx src/cli/index.ts",
     "typecheck": "tsc --noEmit && tsc --noEmit -p web/tsconfig.json",
     "wt:add": "bash scripts/wt-add.sh",
-    "wt:rm": "bash scripts/wt-rm.sh"
+    "wt:rm": "bash scripts/wt-rm.sh",
+    "dev:e2e:up": "bash scripts/dev-e2e-up.sh",
+    "dev:e2e:down": "bash scripts/dev-e2e-down.sh"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/scripts/dev-e2e-down.sh
+++ b/scripts/dev-e2e-down.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Stop this worktree's dev E2E stack (server + daemon started by dev:e2e:up).
+# Usage: npm run dev:e2e:down
+set -euo pipefail
+[ -f .env ] || { echo "✗ no .env in $(pwd)"; exit 1; }
+HOME_DIR=$(grep -E "^OPEN_TAG_HOME=" .env | head -1 | cut -d= -f2- | sed "s|^\$HOME|$HOME|; s|^~|$HOME|")
+RUN="${HOME_DIR:-$HOME/.open-tag}"
+for svc in server daemon; do
+  f="$RUN/dev-e2e-$svc.pid"
+  if [ -f "$f" ]; then
+    pid=$(cat "$f")
+    if kill "$pid" 2>/dev/null; then echo "  stopped $svc ($pid)"; else echo "  $svc not running"; fi
+    rm -f "$f"
+  fi
+done
+echo "✅ dev E2E down"

--- a/scripts/dev-e2e-up.sh
+++ b/scripts/dev-e2e-up.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Bring up an isolated, on-demand dev E2E stack for THIS worktree: server + daemon + dev-bot agent.
+# The server serves the built web/dist on PORT, so browser E2E needs no separate vite process.
+# Usage: npm run dev:e2e:up
+set -euo pipefail
+[ -f .env ] || { echo "✗ no .env in $(pwd) — run from a worktree created by 'npm run wt:add'"; exit 1; }
+
+val() { grep -E "^$1=" .env | head -1 | cut -d= -f2-; }
+PORT=$(val PORT)
+KEY=$(val DAEMON_BOOTSTRAP_KEY)
+HOME_DIR=$(val OPEN_TAG_HOME | sed "s|^\$HOME|$HOME|; s|^~|$HOME|")
+: "${PORT:?PORT missing in .env}" "${KEY:?DAEMON_BOOTSTRAP_KEY missing in .env}"
+RUN="${HOME_DIR:-$HOME/.open-tag}"
+
+command -v claude >/dev/null 2>&1 || { echo "✗ 'claude' CLI not found on PATH — install + authenticate it before dev:e2e (agents won't run otherwise)"; exit 1; }
+
+# Guard against double-up (would collide on PORT).
+if [ -f "$RUN/dev-e2e-server.pid" ] && kill -0 "$(cat "$RUN/dev-e2e-server.pid")" 2>/dev/null; then
+  echo "✗ dev E2E already running for this worktree (server pid $(cat "$RUN/dev-e2e-server.pid")). Run 'npm run dev:e2e:down' first."; exit 1
+fi
+mkdir -p "$RUN/logs"
+
+echo "→ schema + bootstrap seed (idempotent)…"
+npm run db:push >/dev/null 2>&1 || true
+npm run seed    >/dev/null 2>&1 || true
+
+echo "→ building web (served by the server on :$PORT)…"
+npm run build --prefix web >/dev/null
+
+echo "→ starting server (:$PORT)…"
+nohup npx tsx src/server/index.ts > "$RUN/logs/dev-e2e-server.log" 2>&1 & echo $! > "$RUN/dev-e2e-server.pid"
+for i in $(seq 1 30); do curl -sf "http://localhost:$PORT/" >/dev/null 2>&1 && break; sleep 1; done
+curl -sf "http://localhost:$PORT/" >/dev/null 2>&1 || { echo "✗ server did not become healthy — see $RUN/logs/dev-e2e-server.log"; exit 1; }
+
+echo "→ starting daemon…"
+nohup npx tsx src/daemon/index.ts --api-key "$KEY" > "$RUN/logs/dev-e2e-daemon.log" 2>&1 & echo $! > "$RUN/dev-e2e-daemon.pid"
+for i in $(seq 1 30); do [ -s "$RUN/machine-id" ] && break; sleep 1; done
+
+echo "→ seeding dev-bot…"; npm run seed:dev || true
+
+cat <<EOF
+
+✅ dev E2E up (worktree-isolated)
+   data dir : $RUN
+   login    : http://localhost:$PORT/?as=you
+   agent    : @dev-bot  (claude/sonnet) in #all
+   logs     : $RUN/logs/dev-e2e-{server,daemon}.log
+   stop     : npm run dev:e2e:down
+EOF

--- a/scripts/wt-add.sh
+++ b/scripts/wt-add.sh
@@ -16,8 +16,12 @@ VPORT=$(free_port 5301)
 RDB=$(( (SPORT - 7799) % 14 + 2 ))      # redis DB index 2..15 (avoids dev/0, prod/1)
 DB="opentag_$SAFE"
 
-echo "→ worktree=$WT  server=$SPORT  vite=$VPORT  db=$DB  redis=/$RDB"
-git worktree add "$WT" -b "feature/$NAME"
+# Branch from the canonical main, NOT the current HEAD — otherwise a PR made from this
+# worktree would inherit whatever branch you happened to be on. WT_BASE=HEAD to opt out (stacking).
+BASE="${WT_BASE:-origin/main}"
+echo "→ worktree=$WT  server=$SPORT  vite=$VPORT  db=$DB  redis=/$RDB  base=$BASE"
+git fetch origin main --quiet 2>/dev/null || true
+git worktree add "$WT" -b "feature/$NAME" "$BASE"
 docker compose exec -T postgres createdb -U opentag "$DB" 2>/dev/null || echo "  (db $DB already exists, reusing)"
 
 cat > "$WT/.env" <<EOF
@@ -27,6 +31,8 @@ DATABASE_URL=postgres://opentag:opentag@localhost:5433/$DB
 REDIS_URL=redis://localhost:6380/$RDB
 JWT_SECRET=dev-secret-change-me
 DAEMON_BOOTSTRAP_KEY=poc-secret-key
+OPEN_TAG_HOME=$HOME/.open-tag-$SAFE
+ALLOW_DEV_LOGIN=true
 EOF
 
 echo "→ Installing deps + pushing schema + seeding (please wait)…"

--- a/scripts/wt-rm.sh
+++ b/scripts/wt-rm.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
-# Safely remove a worktree: stop its server/vite first, then git worktree remove.
+# Safely remove a worktree: stop its dev stack, git worktree remove, then clean its DB + data dir.
 # Usage: npm run wt:rm -- <name>
 set -euo pipefail
 NAME="${1:-}"
 [ -z "$NAME" ] && { echo "Usage: npm run wt:rm -- <name>"; exit 1; }
 WT="../open-tag-$NAME"
+SAFE="${NAME//[^a-zA-Z0-9]/_}"
 [ -d "$WT" ] || { echo "✗ $WT does not exist"; exit 1; }
 
-# 1) Stop this worktree's server/vite (by the ports in its .env).
+# 1) Stop this worktree's dev E2E stack (server + daemon), then any server/vite still bound to its ports.
 if [ -f "$WT/.env" ]; then
+  ( cd "$WT" && npm run dev:e2e:down >/dev/null 2>&1 ) || true
   for k in PORT VITE_PORT; do
     v=$(grep -E "^$k=" "$WT/.env" | cut -d= -f2 || true)
     [ -n "${v:-}" ] && lsof -ti "tcp:$v" 2>/dev/null | xargs kill 2>/dev/null || true
@@ -17,6 +19,10 @@ fi
 
 # 2) Remove the worktree (--force: it has untracked .env/node_modules).
 git worktree remove "$WT" --force
-echo "✅ worktree '$NAME' removed."
-echo "   Note: database opentag_${NAME//[^a-zA-Z0-9]/_} and branch feature/$NAME are kept (data/branch preserved). To clean up:"
-echo "   docker compose exec -T postgres dropdb -U opentag opentag_${NAME//[^a-zA-Z0-9]/_}  ·  git branch -D feature/$NAME"
+
+# 3) Clean this worktree's isolated data dir + database (ephemeral dev fixtures; derived from NAME, not the now-gone .env).
+rm -rf "$HOME/.open-tag-$SAFE" && echo "  removed data dir ~/.open-tag-$SAFE"
+docker compose exec -T postgres dropdb -U opentag "opentag_$SAFE" 2>/dev/null && echo "  dropped db opentag_$SAFE" || echo "  (db opentag_$SAFE not found / already dropped)"
+
+echo "✅ worktree '$NAME' removed (data dir + db cleaned)."
+echo "   Branch feature/$NAME kept — remove with: git branch -D feature/$NAME"

--- a/src/daemon/agentManager.ts
+++ b/src/daemon/agentManager.ts
@@ -8,8 +8,9 @@ import { ensureOpenTagBin } from "./openTagBin.js";
 import { getRuntime } from "./runtimes.js";
 import type { RuntimeSession, RuntimeCallbacks } from "./runtime.js";
 import { createLogger } from "../log.js";
+import { agentsDir } from "../paths.js";
 
-const DATA_DIR = path.join(os.homedir(), ".open-tag", "agents");
+const DATA_DIR = agentsDir();
 const IDLE_MS = Number(process.env.OPEN_TAG_IDLE_MS ?? 10 * 60 * 1000); // how long before idle sleep (kills process to save memory; next wake uses --resume)
 const DELIVER_DEBOUNCE_MS = Number(process.env.OPEN_TAG_DELIVER_DEBOUNCE_MS ?? 3000); // batching window for deliveries while agent is busy (saves tokens, reduces interruptions)
 

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -10,6 +10,7 @@ import { AgentManager } from "./agentManager.js";
 import { listWorkspace, readWorkspaceFile, listSkills } from "./workspace.js";
 import { detectRuntimes } from "./runtimes.js";
 import { createLogger } from "../log.js";
+import { machineIdFile } from "../paths.js";
 
 const log = createLogger("daemon");
 const args = process.argv.slice(2);
@@ -28,7 +29,7 @@ if (!apiKey) {
 // Stable machine identity: on first connection the server assigns machine.id via ready:ack, persisted to ~/.open-tag/machine-id.
 // Subsequent connections include it so the server can recognize the same machine across restarts,
 // avoiding orphan machine rows from unstable hostnames.
-const MID_FILE = path.join(os.homedir(), ".open-tag", "machine-id");
+const MID_FILE = machineIdFile();
 const readMachineId = (): string | undefined => { try { return fs.readFileSync(MID_FILE, "utf8").trim() || undefined; } catch { return undefined; } };
 const saveMachineId = (id: string): void => { try { fs.mkdirSync(path.dirname(MID_FILE), { recursive: true }); fs.writeFileSync(MID_FILE, id); } catch { /* */ } };
 

--- a/src/daemon/openTagBin.ts
+++ b/src/daemon/openTagBin.ts
@@ -2,11 +2,11 @@
 // Agents call `open-tag ...` from their shell/bash tool → routed to this repo's CLI.
 import fs from "node:fs";
 import path from "node:path";
-import os from "node:os";
 import { fileURLToPath } from "node:url";
+import { binDir } from "../paths.js";
 
 export function ensureOpenTagBin(): string {
-  const dir = path.join(os.homedir(), ".open-tag", "bin");
+  const dir = binDir();
   fs.mkdirSync(dir, { recursive: true });
 
   const here = path.dirname(fileURLToPath(import.meta.url)); // .../src/daemon

--- a/src/daemon/workspace.ts
+++ b/src/daemon/workspace.ts
@@ -4,8 +4,9 @@
 import { readdir, readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
+import { agentsDir } from "../paths.js";
 
-const DATA_DIR = path.join(os.homedir(), ".open-tag", "agents");
+const DATA_DIR = agentsDir();
 const MAX_FILE = 256 * 1024;
 const SKIP = new Set(["node_modules", ".git"]);
 

--- a/src/db/seed-dev.ts
+++ b/src/db/seed-dev.ts
@@ -1,0 +1,27 @@
+// DEV-ONLY fixture: ensure a runnable claude/sonnet agent ("dev-bot") exists in the open-tag
+// workspace + #all, for local human↔agent E2E. Idempotent. Never run on production paths.
+import "../env.js";
+import { db, schema, sql } from "./index.js";
+import { and, eq } from "drizzle-orm";
+
+async function main() {
+  const { servers, agents, channels, channelMembers } = schema;
+  const [server] = await db.select().from(servers).where(eq(servers.slug, "open-tag"));
+  if (!server) { console.error("[seed:dev] no 'open-tag' workspace — run `npm run seed` first"); await sql.end(); process.exit(1); }
+
+  const existing = await db.select().from(agents).where(and(eq(agents.serverId, server.id), eq(agents.name, "dev-bot")));
+  if (existing.length && !existing[0]!.deletedAt) { console.log("[seed:dev] dev-bot already exists, skipping"); await sql.end(); return; }
+
+  const [bot] = await db.insert(agents).values({
+    serverId: server.id, name: "dev-bot", displayName: "Dev Bot",
+    description: "Local dev E2E agent — claude/sonnet. Created by `npm run seed:dev`.",
+    model: "sonnet", runtime: "claude",
+  }).returning();
+
+  const [all] = await db.select().from(channels).where(and(eq(channels.serverId, server.id), eq(channels.name, "all")));
+  if (all) await db.insert(channelMembers).values({ channelId: all.id, memberType: "agent", memberId: bot!.id }).onConflictDoNothing();
+
+  console.log(`[seed:dev] created dev-bot (${bot!.id}) in #all`);
+  await sql.end();
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/log.ts
+++ b/src/log.ts
@@ -2,9 +2,9 @@
 // To tail logs: tail -f ~/.open-tag/logs/server.log  (or daemon/cli/agent-<id>)
 import fs from "node:fs";
 import path from "node:path";
-import os from "node:os";
+import { logsDir } from "./paths.js";
 
-const LOG_DIR = process.env.OPEN_TAG_LOG_DIR ?? path.join(os.homedir(), ".open-tag", "logs");
+const LOG_DIR = logsDir();
 try { fs.mkdirSync(LOG_DIR, { recursive: true }); } catch { /* */ }
 
 type Level = "debug" | "info" | "warn" | "error";

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,13 @@
+// Single source of truth for on-disk locations. OPEN_TAG_HOME (default ~/.open-tag) lets each
+// worktree/dev environment use its own data dir so parallel daemons/agents never collide.
+// Read on each call so env loaded by env.ts (before first use) is honored, and tests can toggle it.
+import os from "node:os";
+import path from "node:path";
+
+export const openTagHome = (): string => process.env.OPEN_TAG_HOME ?? path.join(os.homedir(), ".open-tag");
+export const agentsDir = (): string => path.join(openTagHome(), "agents");
+export const binDir = (): string => path.join(openTagHome(), "bin");
+export const machineIdFile = (): string => path.join(openTagHome(), "machine-id");
+// Legacy specific overrides keep precedence over the HOME-derived default (back-compat).
+export const logsDir = (): string => process.env.OPEN_TAG_LOG_DIR ?? path.join(openTagHome(), "logs");
+export const uploadsDir = (): string => process.env.OPEN_TAG_UPLOAD_DIR ?? path.join(openTagHome(), "uploads");

--- a/src/server/storage.ts
+++ b/src/server/storage.ts
@@ -4,12 +4,12 @@
 import { createWriteStream } from "node:fs";
 import { readFile, mkdir } from "node:fs/promises";
 import path from "node:path";
-import os from "node:os";
 import { randomUUID } from "node:crypto";
 import type { Readable } from "node:stream";
+import { uploadsDir } from "../paths.js";
 
 const DRIVER = process.env.OPEN_TAG_STORAGE ?? "local";
-const LOCAL_DIR = process.env.OPEN_TAG_UPLOAD_DIR ?? path.join(os.homedir(), ".open-tag", "uploads");
+const LOCAL_DIR = uploadsDir();
 
 export interface Saved { key: string; size: number }
 

--- a/test/paths.unit.test.ts
+++ b/test/paths.unit.test.ts
@@ -1,0 +1,39 @@
+// Unit tests for OPEN_TAG_HOME path resolution (no DB / no disk).
+// Run: npx tsx --test --test-force-exit test/paths.unit.test.ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import * as p from "../src/paths.ts";
+
+test("defaults to ~/.open-tag when OPEN_TAG_HOME is unset", () => {
+  delete process.env.OPEN_TAG_HOME;
+  delete process.env.OPEN_TAG_LOG_DIR;
+  delete process.env.OPEN_TAG_UPLOAD_DIR;
+  const home = path.join(os.homedir(), ".open-tag");
+  assert.equal(p.openTagHome(), home);
+  assert.equal(p.agentsDir(), path.join(home, "agents"));
+  assert.equal(p.binDir(), path.join(home, "bin"));
+  assert.equal(p.machineIdFile(), path.join(home, "machine-id"));
+  assert.equal(p.logsDir(), path.join(home, "logs"));
+  assert.equal(p.uploadsDir(), path.join(home, "uploads"));
+});
+
+test("OPEN_TAG_HOME relocates every derived dir", () => {
+  process.env.OPEN_TAG_HOME = "/tmp/ot-wtX";
+  delete process.env.OPEN_TAG_LOG_DIR;
+  delete process.env.OPEN_TAG_UPLOAD_DIR;
+  assert.equal(p.agentsDir(), "/tmp/ot-wtX/agents");
+  assert.equal(p.binDir(), "/tmp/ot-wtX/bin");
+  assert.equal(p.machineIdFile(), "/tmp/ot-wtX/machine-id");
+  assert.equal(p.logsDir(), "/tmp/ot-wtX/logs");
+  assert.equal(p.uploadsDir(), "/tmp/ot-wtX/uploads");
+});
+
+test("legacy OPEN_TAG_LOG_DIR / OPEN_TAG_UPLOAD_DIR still win", () => {
+  process.env.OPEN_TAG_HOME = "/tmp/ot-wtX";
+  process.env.OPEN_TAG_LOG_DIR = "/var/log/ot";
+  process.env.OPEN_TAG_UPLOAD_DIR = "/var/up/ot";
+  assert.equal(p.logsDir(), "/var/log/ot");
+  assert.equal(p.uploadsDir(), "/var/up/ot");
+});


### PR DESCRIPTION
On-demand, per-worktree isolated stack for full **human↔agent** end-to-end verification — bring up a real `claude`/`sonnet` agent in one command, in a workspace that never collides with prod or other worktrees.

## Why
Verifying anything that touches the agent runtime (mention → agent runs → replies; realtime delivery to agents; memory; profile sync) meant hand-signing JWTs, manually creating channels, and there was no ready runnable agent. Parallel worktrees also shared the `~/.open-tag` data dir + a single DB.

## What
- **`OPEN_TAG_HOME` (the one code change)** — `src/paths.ts` is the single source of truth for on-disk locations (`agents/`, `bin/`, `machine-id`, `logs/`, `uploads/`), all derived from `OPEN_TAG_HOME` (default `~/.open-tag`). Wired into the four daemon files + `log.ts` + `storage.ts` (the existing `OPEN_TAG_LOG_DIR`/`OPEN_TAG_UPLOAD_DIR` overrides still win). Default behaviour unchanged → prod unaffected. Unit-tested (`test/paths.unit.test.ts`).
- **wt:add / wt:rm** — `wt:add` now branches from `origin/main` (not the current HEAD, so PRs never inherit an unrelated branch; `WT_BASE=HEAD` opts out) and writes `OPEN_TAG_HOME=~/.open-tag-<name>` + `ALLOW_DEV_LOGIN=true` into the worktree `.env`; `wt:rm` cleans the data dir + drops the DB.
- **`seed:dev`** (`src/db/seed-dev.ts`) — idempotent dev fixture that ensures a `claude`/`sonnet` `dev-bot` in `#all` (complements the now bootstrap-only base seed).
- **`dev:e2e:up` / `dev:e2e:down`** — on-demand: builds web, starts server + daemon (background), waits for readiness, seeds `dev-bot`, prints `http://localhost:$PORT/?as=you`. The server serves built web/dist, so no separate vite. Fail-loud if the `claude` CLI is missing.
- **AGENTS.md** — guidance: spin this up only when a task touches the agent runtime; skip otherwise. Invocation is plain npm scripts (agent-agnostic), never auto-triggered.

## Validation (real, not just typecheck)
- **Unit**: `test/paths.unit.test.ts` 3/3 (default + `OPEN_TAG_HOME` relocation + legacy-override precedence).
- **Isolation (real run)**: brought the stack up with `OPEN_TAG_HOME=~/.open-tag-dev-e2e` — `machine-id`, `bin`, `logs`, and agent workspaces all landed there, **not** in `~/.open-tag` → parallel worktrees are isolated by construction.
- **Full human↔agent E2E (real claude)**: browser dev-login → `#all` → `@dev-bot please reply with the single word: pong` → daemon spawned a real `agent started {runtime: claude, model: sonnet, resume: false}` → `dev-bot: pong` landed in the channel ~13s later and rendered live in the browser. (API + daemon-log + browser DOM all confirmed.)
- `tsc --noEmit` (root + web) + `npm run build --prefix web` green.

Design + plan: `docs/superpowers/specs/2026-06-24-dev-e2e-harness-design.md`, `docs/superpowers/plans/2026-06-24-dev-e2e-harness.md`.
