### PR TITLE
fix(auth): close production auth bypass in human login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,12 @@ PORT=7777
 JWT_SECRET=dev-secret-change-me
 # Bootstrap key used to register the daemon. Registered machines receive an sk_machine_* key.
 DAEMON_BOOTSTRAP_KEY=poc-secret-key
+
+# ── Human auth ──
+# Enable the public dev-login shortcut (POST /api/auth/dev-login → username→JWT, no password).
+# DEVELOPMENT ONLY. Leave unset/false in production; otherwise anyone can mint a 30-day token for any user.
+ALLOW_DEV_LOGIN=true
+# One-time admin bootstrap token for first deploy. Set to a long random value (e.g. `openssl rand -hex 32`) in
+# production, then run once:  curl -X POST $URL/api/auth/setup -d '{"token":"<this>","email":"...","password":"..."}'
+# This sets the seeded owner's password; the endpoint self-closes (410) afterwards. Disabled (404) when unset.
+ADMIN_SETUP_TOKEN=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,3 +140,21 @@ Completing code ≠ completing the task. Verification layers (use every applicab
 
 "Migration succeeded / tests passed / feature OK" is not trusted on its own;
 it must be accompanied by the above checklist.
+
+## Human auth & first deploy
+
+Three separate auth planes — do not conflate them (`src/server/auth.ts`):
+- **human** → JWT (`signUser`/`verifyUser`), endpoints under `/api/auth/*`.
+- **agent** → per-agent token (`Bearer sk_agent_*` + `x-agent-id`), `resolveAgent`, `/agent-api/*`.
+- **daemon** → bootstrap/machine key over WS `/daemon/connect?key=` (`ws.ts`).
+
+Human-auth env flags (`.env` / `.env.prod`):
+- `ALLOW_DEV_LOGIN` — when `true`, `POST /api/auth/dev-login` mints a username→JWT with no
+  password. **Development only; leave unset in production** (the endpoint 404s when off). The
+  frontend never silently falls back to dev-login; an anonymous visitor to `/s/*` is redirected
+  to `/login` by the route guard in `web/src/main.tsx`.
+- `ADMIN_SETUP_TOKEN` — one-time first-deploy admin bootstrap. The seeded owner has no password,
+  so after `npm run seed` set this to a long random value and call once:
+  `curl -X POST $URL/api/auth/setup -d '{"token":"<token>","email":"admin@you","password":"<≥8>"}'`.
+  It sets the owner's password and self-closes (`410 already initialized`) once a password exists.
+  Disabled (`404`) when the token is unset.

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -12,6 +12,38 @@ export function verifyUser(token: string | null): string | null {
   try { return (jwt.verify(token, SECRET) as { uid?: string }).uid ?? null; } catch { return null; }
 }
 
+/** dev-login gate: a public username→JWT shortcut for local dev. Disabled by default so production never ships it open.
+ *  Read at call-time (not module load) so the value is honored even if the env is mutated after import (e.g. tests). */
+export const devLoginEnabled = (): boolean => process.env.ALLOW_DEV_LOGIN === "true";
+
+/** First-deploy admin setup token (`POST /api/auth/setup`). When unset, the setup endpoint is disabled entirely (404). */
+export const setupToken = (): string | null => {
+  const t = process.env.ADMIN_SETUP_TOKEN;
+  return t && t.length > 0 ? t : null;
+};
+
+/** Constant-time string compare for secrets (token/key) — avoids leaking length-prefix matches via timing.
+ *  Length mismatch short-circuits to false but only after a fixed-length compare to keep timing uniform. */
+export function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) { crypto.timingSafeEqual(ab, ab); return false; }
+  return crypto.timingSafeEqual(ab, bb);
+}
+
+// ── Input validation (shared by register / login / setup) ──
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+export const isValidEmail = (email: unknown): email is string =>
+  typeof email === "string" && email.length <= 254 && EMAIL_RE.test(email);
+
+/** Password policy. Returns null when valid, otherwise a human-readable reason (used as the unified error message). */
+export function passwordError(pw: unknown): string | null {
+  if (typeof pw !== "string") return "password required";
+  if (pw.length < 8) return "password must be at least 8 characters";
+  if (pw.length > 200) return "password too long";
+  return null;
+}
+
 export function hashPassword(pw: string): string {
   const salt = crypto.randomBytes(16).toString("hex");
   return `${salt}:${crypto.scryptSync(pw, salt, 32).toString("hex")}`;

--- a/src/server/ratelimit.ts
+++ b/src/server/ratelimit.ts
@@ -1,0 +1,33 @@
+// Minimal in-process fixed-window rate limiter for auth endpoints (login / setup / dev-login / register).
+// Scope & limits: this is a brute-force speed bump, not a DoS shield. It is per-process and in-memory only —
+// it does NOT coordinate across multiple server instances or survive a restart. For a multi-instance deployment,
+// front this with a shared store (Redis) or an edge/WAF rate limit. Documented as a known limitation.
+import type { IncomingMessage } from "node:http";
+
+type Bucket = { count: number; resetAt: number };
+const buckets = new Map<string, Bucket>();
+
+/** Best-effort client identity: trust x-forwarded-for's first hop when present (deploys sit behind a proxy), else the socket address. */
+export function clientIp(req: IncomingMessage): string {
+  const xff = req.headers["x-forwarded-for"];
+  const fwd = Array.isArray(xff) ? xff[0] : xff;
+  if (fwd) return fwd.split(",")[0]!.trim();
+  return req.socket?.remoteAddress ?? "unknown";
+}
+
+/**
+ * Returns { ok, retryAfter } for a (bucket, key) pair. `ok=false` means the window limit is exceeded.
+ * Windows are lazily reset; stale buckets are pruned opportunistically to bound memory.
+ */
+export function rateLimit(bucket: string, key: string, limit = 10, windowMs = 60_000, now = Date.now()): { ok: boolean; retryAfter: number } {
+  const id = `${bucket}:${key}`;
+  const b = buckets.get(id);
+  if (!b || now >= b.resetAt) {
+    buckets.set(id, { count: 1, resetAt: now + windowMs });
+    if (buckets.size > 10_000) for (const [k, v] of buckets) if (now >= v.resetAt) buckets.delete(k); // opportunistic prune
+    return { ok: true, retryAfter: 0 };
+  }
+  if (b.count >= limit) return { ok: false, retryAfter: Math.ceil((b.resetAt - now) / 1000) };
+  b.count++;
+  return { ok: true, retryAfter: 0 };
+}

--- a/src/server/routes-api.ts
+++ b/src/server/routes-api.ts
@@ -3,7 +3,8 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { and, eq, gt, ne, or, inArray, asc, desc, count, isNotNull, isNull, ilike } from "drizzle-orm";
 import { db, schema } from "../db/index.js";
 import { sendJson, sendErr, readJson, bearer, serverIdHeader } from "./util.js";
-import { verifyUser, signUser, hashPassword, verifyPassword, newKey, hashToken } from "./auth.js";
+import { verifyUser, signUser, hashPassword, verifyPassword, newKey, hashToken, devLoginEnabled, setupToken, safeEqual, isValidEmail, passwordError } from "./auth.js";
+import { rateLimit, clientIp } from "./ratelimit.js";
 import { createMessage, getOrCreateDM, getOrCreateThread, convertMessageToTask, claimTask, unclaimTask, setTaskStatus, deleteTask, TASK_STATUSES, startAgent, stopAgent, resetAgent, syncAgentProfile, addReaction, removeReaction, aggregateReactions, saveMessage, unsaveMessage, checkSaved, listSaved, descTooLong, DESC_TOO_LONG, invalidAgentName, INVALID_AGENT_NAME, createServer } from "./core.js";
 import { publish } from "./realtime.js";
 import { requestDaemon } from "./daemonHub.js";
@@ -37,8 +38,13 @@ export async function handleApi(req: IncomingMessage, res: ServerResponse, url: 
   if (!p.startsWith("/api/")) return false;
 
   // ---- auth ----
+  // Dev-login: public username→JWT shortcut for local development ONLY. Gated behind ALLOW_DEV_LOGIN (default off),
+  // so production never exposes it. When disabled it 404s — indistinguishable from a non-existent route (no endpoint leak).
   if (p === "/api/auth/dev-login" && method === "POST") {
-    const { name = "you" } = await readJson(req);
+    if (!devLoginEnabled()) return (sendErr(res, 404, "not found"), true);
+    const b = await readJson(req);
+    const name = String(b.name ?? "you").trim();
+    if (!name || name.length > 64) return (sendErr(res, 400, "invalid name"), true);
     let u = (await db.select().from(schema.users).where(eq(schema.users.name, name)))[0];
     if (!u) [u] = await db.insert(schema.users).values({ name, displayName: name, email: `${name}@dev.local` }).returning();
     // Multi-tenant: each user has isolated data — ensure the user has their own server (creates an empty one if absent, zero channels/agents; "you" owns the seeded default workspace)
@@ -47,19 +53,60 @@ export async function handleApi(req: IncomingMessage, res: ServerResponse, url: 
     if (!u) return (sendErr(res, 500, "dev-login failed"), true);
     return (sendJson(res, 200, { token: signUser(u!.id), user: { id: u!.id, name: u!.name, displayName: u!.displayName } }), true);
   }
-  if (p === "/api/auth/register" && method === "POST") {
+  // First-deploy admin setup: one-time, token-gated. Disabled (404) unless ADMIN_SETUP_TOKEN is configured.
+  // First-run guard: only initializes the seeded default-workspace owner while it still has no password — so it
+  // self-closes (410) once an admin password exists. This unblocks the seeded "you" admin after dev-login is turned off,
+  // without ever hard-coding a default password. Placed BEFORE the auth gate (the operator has no JWT yet).
+  if (p === "/api/auth/setup" && method === "POST") {
+    const tok = setupToken();
+    if (!tok) return (sendErr(res, 404, "not found"), true);
+    const rl = rateLimit("auth:setup", clientIp(req), 5);
+    if (!rl.ok) return (sendErr(res, 429, "too many requests", { retryAfter: rl.retryAfter }), true);
     const b = await readJson(req);
-    if (!b.name || !b.email || !b.password) return (sendErr(res, 400, "name/email/password required"), true);
-    const dup = (await db.select().from(schema.users).where(or(eq(schema.users.email, b.email), eq(schema.users.name, b.name))))[0];
+    if (!safeEqual(String(b.token ?? ""), tok)) return (sendErr(res, 403, "invalid setup token"), true);
+    const ws = (await db.select().from(schema.servers).where(eq(schema.servers.slug, "open-tag")))[0];
+    if (!ws) return (sendErr(res, 409, "no default workspace; run seed first"), true);
+    const admin = (await db.select().from(schema.users).where(eq(schema.users.id, ws.ownerId)))[0];
+    if (!admin) return (sendErr(res, 409, "default workspace owner missing"), true);
+    if (admin.passwordHash) return (sendErr(res, 410, "already initialized"), true);
+    const pwErr = passwordError(b.password);
+    if (pwErr) return (sendErr(res, 400, pwErr), true);
+    const patch: Record<string, unknown> = { passwordHash: hashPassword(String(b.password)) };
+    if (b.email !== undefined) {
+      if (!isValidEmail(b.email)) return (sendErr(res, 400, "invalid email"), true);
+      if (b.email !== admin.email) {
+        const dup = (await db.select().from(schema.users).where(eq(schema.users.email, b.email)))[0];
+        if (dup) return (sendErr(res, 409, "email already in use"), true);
+        patch.email = b.email;
+      }
+    }
+    if (typeof b.displayName === "string" && b.displayName.trim()) patch.displayName = b.displayName.trim();
+    await db.update(schema.users).set(patch).where(eq(schema.users.id, admin.id));
+    return (sendJson(res, 200, { token: signUser(admin.id), user: { id: admin.id, name: admin.name, email: (patch.email as string) ?? admin.email } }), true);
+  }
+  if (p === "/api/auth/register" && method === "POST") {
+    const rl = rateLimit("auth:register", clientIp(req));
+    if (!rl.ok) return (sendErr(res, 429, "too many requests", { retryAfter: rl.retryAfter }), true);
+    const b = await readJson(req);
+    const name = typeof b.name === "string" ? b.name.trim() : "";
+    if (!name || name.length > 64) return (sendErr(res, 400, "invalid name"), true);
+    if (!isValidEmail(b.email)) return (sendErr(res, 400, "invalid email"), true);
+    const pwErr = passwordError(b.password);
+    if (pwErr) return (sendErr(res, 400, pwErr), true);
+    const dup = (await db.select().from(schema.users).where(or(eq(schema.users.email, b.email), eq(schema.users.name, name))))[0];
     if (dup) return (sendErr(res, 409, dup.email === b.email ? "email already registered" : "username already taken"), true);
-    const [u] = await db.insert(schema.users).values({ name: b.name, displayName: b.displayName ?? b.name, email: b.email, passwordHash: hashPassword(b.password) }).returning();
-    await createServer(`${b.name}'s workspace`, `u-${u!.id.slice(0, 8)}`, u!.id); // Create personal workspace on registration (aligned with dev-login; without it, entering the app with no server causes bootstrap to crash)
+    const [u] = await db.insert(schema.users).values({ name, displayName: typeof b.displayName === "string" && b.displayName.trim() ? b.displayName.trim() : name, email: b.email, passwordHash: hashPassword(String(b.password)) }).returning();
+    await createServer(`${name}'s workspace`, `u-${u!.id.slice(0, 8)}`, u!.id); // Create personal workspace on registration (aligned with dev-login; without it, entering the app with no server causes bootstrap to crash)
     return (sendJson(res, 200, { token: signUser(u!.id), user: { id: u!.id, name: u!.name } }), true);
   }
+  // Login: generic 401 on any failure (no user enumeration — same response whether the email is unknown or the password is wrong).
   if (p === "/api/auth/login" && method === "POST") {
+    const rl = rateLimit("auth:login", clientIp(req));
+    if (!rl.ok) return (sendErr(res, 429, "too many requests", { retryAfter: rl.retryAfter }), true);
     const b = await readJson(req);
-    const u = (await db.select().from(schema.users).where(eq(schema.users.email, b.email ?? "")))[0];
-    if (!u || !verifyPassword(b.password ?? "", u.passwordHash)) return (sendErr(res, 401, "bad credentials"), true);
+    if (typeof b.email !== "string" || typeof b.password !== "string") return (sendErr(res, 400, "email and password required"), true);
+    const u = (await db.select().from(schema.users).where(eq(schema.users.email, b.email)))[0];
+    if (!u || !verifyPassword(b.password, u.passwordHash)) return (sendErr(res, 401, "bad credentials"), true);
     return (sendJson(res, 200, { token: signUser(u.id), user: { id: u.id, name: u.name } }), true);
   }
   // Invite info (public, no auth required): the /join/:token landing page uses this to display "X invited you to join workspace Y"

--- a/test/auth.unit.test.ts
+++ b/test/auth.unit.test.ts
@@ -1,0 +1,81 @@
+// Unit tests for human-auth primitives (no DB / no network).
+// Run: npx tsx --test --test-force-exit test/auth.unit.test.ts
+// JWT_SECRET is pinned before importing auth.ts so signed/forged tokens are deterministic.
+import test from "node:test";
+import assert from "node:assert/strict";
+import jwt from "jsonwebtoken";
+
+process.env.JWT_SECRET = "test-secret";
+const auth = await import("../src/server/auth.ts");
+
+test("signUser / verifyUser round-trip returns the uid", () => {
+  const token = auth.signUser("user-123");
+  assert.equal(auth.verifyUser(token), "user-123");
+});
+
+test("verifyUser rejects null, garbage, tampered, and wrong-secret tokens", () => {
+  assert.equal(auth.verifyUser(null), null);
+  assert.equal(auth.verifyUser(""), null);
+  assert.equal(auth.verifyUser("not.a.jwt"), null);
+  const tampered = auth.signUser("user-123").slice(0, -2) + "xx";
+  assert.equal(auth.verifyUser(tampered), null);
+  const wrongSecret = jwt.sign({ uid: "user-123" }, "other-secret", { expiresIn: "30d" });
+  assert.equal(auth.verifyUser(wrongSecret), null);
+});
+
+test("verifyUser rejects an expired token", () => {
+  const expired = jwt.sign({ uid: "user-123" }, "test-secret", { expiresIn: "-1s" });
+  assert.equal(auth.verifyUser(expired), null);
+});
+
+test("hashPassword / verifyPassword", () => {
+  const stored = auth.hashPassword("correct horse battery staple");
+  assert.ok(stored.includes(":"));
+  assert.equal(auth.verifyPassword("correct horse battery staple", stored), true);
+  assert.equal(auth.verifyPassword("wrong password", stored), false);
+  assert.equal(auth.verifyPassword("anything", null), false);
+  assert.equal(auth.verifyPassword("anything", "no-colon"), false);
+  // salted: two hashes of the same password differ
+  assert.notEqual(auth.hashPassword("same"), auth.hashPassword("same"));
+});
+
+test("safeEqual", () => {
+  assert.equal(auth.safeEqual("abc", "abc"), true);
+  assert.equal(auth.safeEqual("abc", "abd"), false);
+  assert.equal(auth.safeEqual("abc", "abcd"), false);
+  assert.equal(auth.safeEqual("", ""), true);
+});
+
+test("isValidEmail", () => {
+  for (const ok of ["a@b.co", "user.name+tag@sub.example.com"]) assert.equal(auth.isValidEmail(ok), true, ok);
+  for (const bad of ["", "nope", "a@b", "a@@b.co", "a b@c.co", 42 as any, null as any]) assert.equal(auth.isValidEmail(bad), false, String(bad));
+});
+
+test("passwordError enforces length policy", () => {
+  assert.equal(auth.passwordError("12345678"), null);
+  assert.match(auth.passwordError("short") ?? "", /at least 8/);
+  assert.match(auth.passwordError("x".repeat(201)) ?? "", /too long/);
+  assert.match(auth.passwordError(undefined) ?? "", /required/);
+});
+
+test("devLoginEnabled reads env at call-time, default off", () => {
+  delete process.env.ALLOW_DEV_LOGIN;
+  assert.equal(auth.devLoginEnabled(), false);
+  process.env.ALLOW_DEV_LOGIN = "false";
+  assert.equal(auth.devLoginEnabled(), false);
+  process.env.ALLOW_DEV_LOGIN = "1";
+  assert.equal(auth.devLoginEnabled(), false, "only the exact string 'true' enables it");
+  process.env.ALLOW_DEV_LOGIN = "true";
+  assert.equal(auth.devLoginEnabled(), true);
+  delete process.env.ALLOW_DEV_LOGIN;
+});
+
+test("setupToken returns null when unset/empty", () => {
+  delete process.env.ADMIN_SETUP_TOKEN;
+  assert.equal(auth.setupToken(), null);
+  process.env.ADMIN_SETUP_TOKEN = "";
+  assert.equal(auth.setupToken(), null);
+  process.env.ADMIN_SETUP_TOKEN = "tok_abc";
+  assert.equal(auth.setupToken(), "tok_abc");
+  delete process.env.ADMIN_SETUP_TOKEN;
+});

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -12,23 +12,22 @@ import { Landing } from "./views/Landing.tsx";
 import "./i18n";
 import "./styles.css";
 
-// Capture ?as=<devuser> as early as possible: must run before React/Router mounts, otherwise the wildcard route's Navigate replace clears the query string before dev-login can read it.
-const _as = new URLSearchParams(window.location.search).get("as");
-if (_as) localStorage.setItem("open-tag.devuser", _as);
-
-// Root / unmatched path → wait for bootstrap, then redirect to the current user's own workspace.
+// Root / unmatched path → wait for bootstrap, then redirect to the current user's own workspace (or /login if anonymous).
 function RootRedirect() {
-  const { slug, ready } = useStore();
-  if (!ready) return null; // wait for bootstrap to set slug before redirecting
+  const { slug, ready, authState } = useStore();
+  if (!ready) return null; // wait for bootstrap to resolve auth + slug before redirecting
+  if (authState !== "authed") return <Navigate to="/login" replace />;
   return <Navigate to={`/s/${slug}/channel`} replace />;
 }
 
-// Canonicalize stale or invalid workspace slugs while preserving the current nested route.
+// Auth guard + slug canonicalization for /s/:server/*. The auth check runs BEFORE <Layout/> renders, so an
+// unauthenticated visitor is redirected to /login without the workspace ever painting (no flash of protected UI).
 function WorkspaceRoute() {
-  const { slug, ready } = useStore();
+  const { slug, ready, authState } = useStore();
   const { server } = useParams();
   const loc = useLocation();
-  if (!ready) return null;
+  if (!ready) return null; // bootstrap in flight: render nothing (not the workspace)
+  if (authState !== "authed") return <Navigate to="/login" replace />; // hard auth gate
   if (server !== slug) {
     const pathname = loc.pathname.replace(/^\/s\/[^/]+/, `/s/${slug}`);
     return <Navigate to={`${pathname}${loc.search}${loc.hash}`} replace />;

--- a/web/src/store.tsx
+++ b/web/src/store.tsx
@@ -16,7 +16,7 @@ export interface Msg { id: string; seq: number; channelId: string; senderType: s
 type Ev = { type: string; [k: string]: any };
 
 interface Store {
-  ready: boolean; serverId: string; slug: string; me: Me | null; myRole: string; serverAvatar: string | null;
+  ready: boolean; authState: "loading" | "authed" | "anon"; serverId: string; slug: string; me: Me | null; myRole: string; serverAvatar: string | null;
   servers: ServerInfo[]; capabilities: Record<string, boolean>;
   uploadServerAvatar: (file: File) => Promise<void>;
   uploadAgentAvatar: (agentId: string, file: File) => Promise<string>;
@@ -50,6 +50,7 @@ export const useStore = () => useContext(Ctx);
 
 export function StoreProvider({ children }: { children: ReactNode }) {
   const [ready, setReady] = useState(false);
+  const [authState, setAuthState] = useState<"loading" | "authed" | "anon">("loading"); // human-auth gate: drives the /s/* route guard (no dev-login fallback)
   const [serverId, setServerId] = useState("");
   const [slug, setSlug] = useState("open-tag");
   const [servers, setServers] = useState<ServerInfo[]>([]);          // all servers the user belongs to (used by server switcher)
@@ -158,24 +159,28 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     let unreadTimer: ReturnType<typeof setTimeout> | null = null;
     const syncUnread = () => { if (unreadTimer) clearTimeout(unreadTimer); unreadTimer = setTimeout(async () => { try { setUnread((await api("GET", "/api/channels/unread")) || {}); } catch { /* keep stale value on error */ } }, 400); };
     (async () => {
+      // Resolve a session token. Precedence: explicit ?as= dev-login (dev only) > stored JWT. NO silent fallback —
+      // an anonymous visitor never auto-logs-in; the /s/* route guard sends them to /login (see main.tsx).
       const asParam = new URLSearchParams(window.location.search).get("as");
-      const storedToken = localStorage.getItem("open-tag.token"); // JWT persisted after real register/login; not set in dev (?as=) flow
-      const isAuthRoute = /^\/(login|register|join)\b/.test(window.location.pathname);
-      if (isAuthRoute && !storedToken && !asParam) { setReady(true); return; } // auth page without a token: let AuthPage/JoinPage handle its own fetch
-      let login: any = null;
-      if (storedToken && !asParam) { // real auth token: use stored JWT, fall back to dev-login if expired
-        tokenRef.current = storedToken;
-        const meRes = await (await fetch("/api/auth/me", { headers: { authorization: "Bearer " + storedToken } })).json().catch(() => null);
-        if (meRes?.id) { setMe(meRes); login = { token: storedToken, user: meRes }; } else localStorage.removeItem("open-tag.token");
+      let token: string | null = null;
+      let user: Me | null = null;
+      if (asParam) { // explicit developer action: dev-login only succeeds when the backend has ALLOW_DEV_LOGIN=true; on success persist the JWT as a normal session
+        const r = await fetch("/api/auth/dev-login", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ name: asParam }) });
+        if (r.ok) { const d = await r.json().catch(() => null); if (d?.token) { token = d.token; user = d.user ?? null; localStorage.setItem("open-tag.token", d.token); } }
       }
-      if (!login) { // dev-login (?as= user switch or default "you")
-        const asUser = asParam || localStorage.getItem("open-tag.devuser") || "you";
-        if (asParam) localStorage.setItem("open-tag.devuser", asUser);
-        login = await (await fetch("/api/auth/dev-login", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ name: asUser }) })).json();
-        tokenRef.current = login.token;
-        if (login.user) setMe(login.user);
+      if (!token) {
+        const storedToken = localStorage.getItem("open-tag.token"); // JWT persisted after real register/login (or dev-login above)
+        if (storedToken) {
+          const meRes = await (await fetch("/api/auth/me", { headers: { authorization: "Bearer " + storedToken } })).json().catch(() => null);
+          if (meRes?.id) { token = storedToken; user = meRes; }
+          else localStorage.removeItem("open-tag.token"); // expired / invalid / 401 → drop it so the guard redirects to /login
+        }
       }
-      const myId = login.user?.id;
+      if (!token) { setAuthState("anon"); setReady(true); return; } // unauthenticated: auth pages & landing render; protected routes redirect to /login
+      tokenRef.current = token;
+      setMe(user);
+      setAuthState("authed");
+      const myId = user?.id;
       const serverList: ServerInfo[] = await (await fetch("/api/servers", { headers: { authorization: "Bearer " + tokenRef.current } })).json();
       setServers(serverList);
       const urlSlug = location.pathname.match(/\/s\/([^/]+)/)?.[1]; // resolve workspace from URL /s/:slug (multi-workspace support); fall back to first
@@ -248,7 +253,7 @@ export function StoreProvider({ children }: { children: ReactNode }) {
     return () => { cancelled = true; sock?.close(); if (unreadTimer) clearTimeout(unreadTimer); };
   }, []);
 
-  return <Ctx.Provider value={{ ready, serverId, slug, me, myRole, serverAvatar, servers, capabilities, createServer, logout, uploadServerAvatar, uploadAgentAvatar, uploadUserAvatar, channels, dms, unread, agents, machines, humans, api, reload, onEvent, subscribeChannel, createChannel, markActionExecuted, createTasks, openDM, joinChannel, leaveChannel, markRead, uploadFiles, uploadOne, attachmentUrl, react, openThread, savedIds, saveMsg, unsaveMsg, listSaved }}>{children}</Ctx.Provider>;
+  return <Ctx.Provider value={{ ready, authState, serverId, slug, me, myRole, serverAvatar, servers, capabilities, createServer, logout, uploadServerAvatar, uploadAgentAvatar, uploadUserAvatar, channels, dms, unread, agents, machines, humans, api, reload, onEvent, subscribeChannel, createChannel, markActionExecuted, createTasks, openDM, joinChannel, leaveChannel, markRead, uploadFiles, uploadOne, attachmentUrl, react, openThread, savedIds, saveMsg, unsaveMsg, listSaved }}>{children}</Ctx.Provider>;
 }
 
 export const fmtTime = (iso?: string) => { try { return iso ? new Date(iso).toLocaleTimeString("zh-CN", { hour12: false }) : ""; } catch { return ""; } };


### PR DESCRIPTION
## Problem

`dev-login` was public in **every** environment and the web client silently fell back to it (default user `you`) whenever a token was missing or invalid — so opening `/s/*` entered the workspace with a 30-day JWT and **real auth was bypassed**. `/s/*` had no auth guard either.

## Fix

Backend (`src/server`):
- `auth.ts`: `devLoginEnabled()` (`ALLOW_DEV_LOGIN`, default **off**), `setupToken()`, constant-time `safeEqual()`, `isValidEmail()` / `passwordError()` validators.
- `routes-api.ts`: `dev-login` 404s unless `ALLOW_DEV_LOGIN=true`; new token-gated, first-run-only `POST /api/auth/setup` to initialize the seeded admin's password (no hard-coded default); login/register input validation + generic 401 (no user enumeration); rate-limit login/register/setup.
- `ratelimit.ts`: in-process fixed-window limiter (documented single-instance limitation).

Frontend (`web/src`):
- `store.tsx`: remove the silent dev-login fallback; add `authState` (loading/authed/anon); dev-login only on explicit `?as=` (dev); clear token + go anon on missing/expired token or `/api/auth/me` 401.
- `main.tsx`: `/s/*` route guard redirects anonymous visitors to `/login` before Layout renders.

agent (`/agent-api`) and daemon (WS machine key) auth planes are untouched.

## Note on history

This is the previously-authored fix (`16139bc`) **rebased onto current `main`** — it had been sitting on a local branch and never merged. The rebase touched only two import/JSX-props lines (`routes-api.ts` imports, `store.tsx` context-provider members); **no auth logic changed** from the originally-verified commit.

## Validation (re-run after rebase)

- `npm run typecheck` (root + web) clean; **31/31 unit tests pass** (incl. the auth-primitive suite).
- `npm run build` (web) succeeds.
- **Runtime smoke (production posture, `ALLOW_DEV_LOGIN` unset)**: `POST /api/auth/dev-login → 404`, `GET /api/auth/me` (no token) `→ 401`, `POST /api/auth/login` (empty) `→ 400`.

Docs: `AGENTS.md` three-plane auth + first-deploy setup; `.env.example` flags.
