### PR TITLE
feat(docker): one-command containerized control plane (app = API + web)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Build context hygiene: keep secrets, local state, and reinstalled/rebuilt artifacts out of the image.
+.git
+node_modules
+**/node_modules
+web/dist
+dist
+logs
+*.log
+# Never bake env/secrets into the image — they are injected at runtime via compose env_file.
+.env
+.env.*
+# Local-only / private material (also excluded from the public repo)
+CLAUDE.local.md
+reference
+recon
+_vendor
+.DS_Store

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,0 +1,19 @@
+# Copy to .env.docker before running:  docker compose --profile app up -d --build
+# .env.docker is gitignored — never commit real secrets.
+
+# Internal service DNS for the bundled compose stack — leave as-is (these are the compose service names,
+# NOT host localhost:5433/6380).
+DATABASE_URL=postgres://opentag:opentag@postgres:5432/opentag
+REDIS_URL=redis://redis:6379
+PORT=7788
+
+# Secrets — generate strong values:  openssl rand -hex 32
+JWT_SECRET=
+# Host daemon must connect with this exact value as its --api-key.
+DAEMON_BOOTSTRAP_KEY=
+# One-time admin bootstrap token for POST /api/auth/setup. Clear it after first use.
+ADMIN_SETUP_TOKEN=
+
+# Public username->JWT dev shortcut. Leave UNSET in production.
+# Set to true only for local/dev stacks to enable POST /api/auth/dev-login.
+# ALLOW_DEV_LOGIN=true

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 web/dist/
 .env*
 !.env.example
+!.env.docker.example
 *.log
 logs/
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+# Control-plane image: builds the web client and serves it together with the API from one Node process.
+# The daemon (compute plane) is intentionally NOT in this image — it runs on the user's own host with their
+# CLIs/credentials/code and connects back over the published WS port. See docs/docker.md.
+
+# ---- build stage: install deps + build the web client (Vite → web/dist) ----
+FROM node:22-slim AS build
+WORKDIR /app
+ENV NODE_ENV=development
+# Root deps first (server runs via tsx and pushes schema via drizzle-kit at runtime, so full deps are needed).
+COPY package.json package-lock.json ./
+RUN npm ci
+# Web deps, then build.
+COPY web/package.json web/package-lock.json ./web/
+RUN npm --prefix web ci
+COPY . .
+RUN npm run web:build
+
+# ---- runtime stage: source + root node_modules + built client, run with tsx ----
+FROM node:22-slim AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/web/dist ./web/dist
+COPY --from=build /app/src ./src
+COPY --from=build /app/drizzle.config.ts ./drizzle.config.ts
+COPY --from=build /app/tsconfig.json ./tsconfig.json
+COPY --from=build /app/package.json ./package.json
+COPY scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh && chown -R node:node /app
+USER node
+EXPOSE 7788
+# Liveness via the app's own /health (Node 22 has global fetch; no curl/wget needed in the slim image).
+HEALTHCHECK --interval=10s --timeout=5s --start-period=40s --retries=6 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||7788)+'/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,20 @@ services:
       timeout: 3s
       retries: 10
 
+  # Control plane (API + web). Opt-in via `--profile app` so `npm run infra` (no profile) still brings up
+  # only postgres+redis for host-run development. The daemon is NOT here — run it on your host (see docs/docker.md).
+  app:
+    build: { context: ., dockerfile: Dockerfile }
+    image: open-tag-app:latest
+    container_name: open-tag-app
+    profiles: ["app"]
+    env_file: [.env.docker]            # copy .env.docker.example → .env.docker and fill the secrets first
+    ports: ["${APP_PORT:-7788}:7788"]
+    depends_on:
+      postgres: { condition: service_healthy }
+      redis: { condition: service_healthy }
+    restart: unless-stopped
+
 volumes:
   pgdata: {}
   redisdata: {}

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,48 @@
+# Docker: one-command control plane
+
+`docker compose --profile app up` runs the **control plane** — Postgres + Redis + the
+API/web server — in containers. The **daemon (compute plane) stays on your host**: it runs
+your locally-installed agent CLIs (`claude`/`codex`/`gemini`/`opencode`) against your code and
+credentials, so it is not containerized. You connect it yourself after the stack is up.
+
+## What is / isn't containerized
+
+| Plane | Where it runs | How |
+|---|---|---|
+| Postgres + Redis | container | compose services `postgres`, `redis` |
+| API + web (control plane) | container | compose service `app` (this image) |
+| daemon + agents (compute plane) | **your host** | `npm run daemon` — connects over the published WS port |
+
+## First run
+
+```bash
+# 1. Configure secrets (never committed)
+cp .env.docker.example .env.docker
+#    fill JWT_SECRET, DAEMON_BOOTSTRAP_KEY, ADMIN_SETUP_TOKEN — each: openssl rand -hex 32
+#    leave ALLOW_DEV_LOGIN unset (production default: dev-login is disabled)
+
+# 2. Build + start postgres + redis + app (schema push + seed run automatically on boot)
+docker compose --profile app up -d --build
+
+# 3. Initialize the admin once (no hard-coded password; the endpoint self-closes afterwards)
+curl -X POST http://localhost:7788/api/auth/setup \
+  -H 'content-type: application/json' \
+  -d '{"token":"<ADMIN_SETUP_TOKEN>","email":"you@example.com","password":"<min 8 chars>"}'
+#    then clear ADMIN_SETUP_TOKEN from .env.docker
+
+# 4. Connect your machine (host daemon → containerized server). --api-key MUST equal DAEMON_BOOTSTRAP_KEY.
+npx tsx src/daemon/index.ts --server-url http://localhost:7788 --api-key <DAEMON_BOOTSTRAP_KEY>
+```
+
+Open `http://localhost:7788`, sign in with the admin email/password, create an agent, and mention it in `#all`.
+
+## Notes
+
+- `npm run infra` (no `--profile app`) still starts only postgres+redis — the host-run dev workflow
+  (`npm run server` / `npm run daemon`) is unchanged.
+- The `app` container reads config from `.env.docker` only (compose `env_file`); `DATABASE_URL`/`REDIS_URL`
+  point at the internal service DNS (`postgres:5432` / `redis:6379`), not host `localhost:5433/6380`.
+- Override the published port with `APP_PORT` (e.g. `APP_PORT=8080 docker compose --profile app up -d`).
+  Stop any host-run server on the same port first.
+- Schema migration (`drizzle-kit push`) and seed run on every container start; both are idempotent.
+- Three auth planes and the `ALLOW_DEV_LOGIN` / `ADMIN_SETUP_TOKEN` flags are described in `AGENTS.md`.

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Control-plane container entrypoint: bring the schema and bootstrap data up to date (both idempotent),
+# then hand off to the server. Postgres/Redis readiness is guaranteed by compose `depends_on: service_healthy`.
+set -e
+
+echo "[entrypoint] applying schema (drizzle-kit push, idempotent)..."
+npx drizzle-kit push --force
+
+echo "[entrypoint] seeding bootstrap data (idempotent — skips if the workspace already exists)..."
+npx tsx src/db/seed.ts
+
+echo "[entrypoint] starting control plane on :${PORT:-7788} ..."
+exec npx tsx src/server/index.ts


### PR DESCRIPTION
One-command containerized **control plane** (API + web in one Node process). The compute plane (daemon) intentionally stays on the host with the user's CLIs/credentials/code and connects back over the published WS port.

## What
- **`Dockerfile`** — multi-stage: build stage installs deps + builds the web client (Vite → `web/dist`); runtime stage copies source + `node_modules` + `web/dist` and runs with `tsx`. Non-root `node` user, `EXPOSE 7788`, `HEALTHCHECK` hitting `/health` (Node 22 global fetch, no curl in the slim image).
- **`docker-compose.yml`** — adds an `app` service **gated behind `profiles: ["app"]`**, so `npm run infra` (no profile) still brings up only postgres+redis for host-run dev; `docker compose --profile app up` brings up the full stack. `app` waits on `postgres`/`redis` healthchecks.
- **`scripts/docker-entrypoint.sh`** — idempotent: `drizzle-kit push` (schema) → `seed.ts` (bootstrap) → start server.
- **`.env.docker.example`** — compose-internal DNS (`postgres:5432` / `redis:6379`) + secrets to fill (`JWT_SECRET`, `DAEMON_BOOTSTRAP_KEY`, `ADMIN_SETUP_TOKEN`), `ALLOW_DEV_LOGIN` optional.
- **`.dockerignore`**, **`docs/docker.md`** (run instructions), `.gitignore` (ignore `.env.docker`).

The daemon is **not** containerized — see `docs/docker.md` for connecting a host daemon.

## Validation (real build + run, not just typecheck)
Built the image and ran the container against host Postgres/Redis:
- `docker build` → `open-tag-app:verify` (656 MB) ✓
- container boots: entrypoint logged `applying schema (drizzle-kit push)` → `seeding bootstrap data` → `control plane up` ✓
- `GET /health` → `{"ok":true,"service":"open-tag",...}` ✓
- container reports **`Up (healthy)`** (HEALTHCHECK passes) ✓
- web UI served from the container: `<title>open-tag</title>` + built assets `index-*.js/.css` ✓
- real API through the containerized stack: dev-login → `GET /api/servers` → `['open-tag']` (the seeded workspace) ✓
- `tsc --noEmit` green.

Then torn down (container + test DB + image removed).

> Scope: only the docker control-plane image/compose/entrypoint/docs. The auth-bypass fix that previously shared this feature branch is already on main (#13); this PR is docker-only.
