### PR TITLE
fix: prod:down unbound PORT + post-auth redirect to channel (not Landing)

### DIFF
--- a/scripts/prod-down.sh
+++ b/scripts/prod-down.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 [ -f .env.prod ] || { echo "✗ no .env.prod in $(pwd)"; exit 1; }
 PORT=$(grep -E "^PORT=" .env.prod | head -1 | cut -d= -f2- || true); PORT="${PORT:-7788}"
 
-echo "→ stopping server listener on :$PORT…"
+echo "→ stopping server listener on :${PORT}…"
 lsof -ti "tcp:$PORT" -sTCP:LISTEN 2>/dev/null | xargs kill 2>/dev/null || true
 
 echo "→ stopping open-tag prod daemon…"

--- a/web/src/views/Auth.tsx
+++ b/web/src/views/Auth.tsx
@@ -3,11 +3,22 @@ import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
-// On successful login/register: persist token, clear dev user, and redirect to target (defaults to root → RootRedirect to own workspace).
+// On successful login/register: persist token, clear dev user, and redirect to target. The caller resolves the
+// user's workspace (see workspaceHome); "/" is only a defensive fallback (it renders the marketing Landing, NOT a redirect).
 function finishAuth(token: string, to = "/") {
   localStorage.setItem("open-tag.token", token);
   localStorage.removeItem("open-tag.devuser"); // clear dev user so dev-login doesn't override the real account
   window.location.assign(to);
+}
+
+// Where to land after auth: the user's first workspace, resolved from the SAME source bootstrap uses
+// (GET /api/servers → serverList[0]) so the target always matches RootRedirect. Falls back to "/" if none.
+async function workspaceHome(token: string): Promise<string> {
+  try {
+    const servers = await (await fetch("/api/servers", { headers: { authorization: "Bearer " + token } })).json();
+    const slug = Array.isArray(servers) ? servers[0]?.slug : null;
+    return slug ? `/s/${slug}/channel` : "/";
+  } catch { return "/"; }
 }
 
 export function AuthPage({ mode }: { mode: "login" | "register" }) {
@@ -25,7 +36,7 @@ export function AuthPage({ mode }: { mode: "login" | "register" }) {
       const r = await fetch(`/api/auth/${mode}`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
       const d = await r.json();
       if (!r.ok || !d.token) throw new Error(d.error || t("auth.opFailed"));
-      finishAuth(d.token);
+      finishAuth(d.token, await workspaceHome(d.token));
     } catch (e: any) { setErr(String(e?.message || e)); } finally { setBusy(false); }
   };
   return (


### PR DESCRIPTION
Closes #24.

Two small operational bugs, fixed + verified together.

## 1. `prod:down` crashed before stopping anything

`scripts/prod-down.sh:9` was `echo "→ stopping server listener on :$PORT…"` — the ellipsis `…` (U+2026) abuts `$PORT`, so under `set -u` bash folds the multibyte byte into the parameter name and aborts with `PORT…: unbound variable` **before any process is killed**. `npm run prod:down` stopped nothing. (`prod-up.sh` survives only because its `$PORT` is followed by a space.)

**Fix:** brace it → `:${PORT}…`.

## 2. Register/login landed on the marketing Landing, not your channel

`web/src/views/Auth.tsx` `finishAuth(token, to = "/")` redirected to `/` after auth. A stale comment claimed `/` → RootRedirect, but `main.tsx` routes `/` → `<Landing />` (RootRedirect only handles `*`), and Landing doesn't auto-forward authed users. Result: stranded on the marketing page. Affected **both** login and register.

**Fix:** after auth, resolve the destination from `GET /api/servers` — the exact source `store.tsx` bootstrap uses (`serverList[0]`) — and redirect to `/s/<slug>/channel`, mirroring the existing `JoinPage` pattern. Frontend-only; no slug duplication on the backend, so it can't drift from bootstrap.

## Verification

- `npm run typecheck` (root + web) → exit 0
- `prod-down.sh`: `bash -n` OK + deterministic parse proof under `set -u` — old `:$PORT…` → `PORT…: unbound variable`, new `:${PORT}…` → `on :7788…`
- **Real browser (chrome-devtools, isolated stack on :7801):**
  - Register `alice` → `http://localhost:7801/s/u-37319135/channel/<#all>` — channel UI rendered (workspace switcher "alice's workspace", `# all`, composer), **not** `/`
  - Login `alice` → `http://localhost:7801/s/u-37319135/channel`

Verified in an isolated worktree, not against prod.
