### PR TITLE
chore(rename): drop internal 'fancy-loop' codename from prod-down.sh comments

### DIFF
--- a/scripts/prod-down.sh
+++ b/scripts/prod-down.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Stop the open-tag production control plane: the server LISTENER + the open-tag prod daemon.
-# Daemons for other workspaces (machine-key daemons / other repos, e.g. fancy-loop) are left alone.
+# Daemons for other workspaces (machine-key daemons from a separate repo) are left alone.
 # Usage: npm run prod:down
 set -euo pipefail
 [ -f .env.prod ] || { echo "✗ no .env.prod in $(pwd)"; exit 1; }
@@ -11,6 +11,6 @@ lsof -ti "tcp:$PORT" -sTCP:LISTEN 2>/dev/null | xargs kill 2>/dev/null || true
 
 echo "→ stopping open-tag prod daemon…"
 pkill -f "ENV_FILE=.env.prod tsx src/daemon/index.ts" 2>/dev/null || true   # the launcher shell
-pkill -f "open-tag/node_modules.*tsx.*src/daemon/index.ts" 2>/dev/null || true  # its tsx/node child (this checkout only; not worktrees / fancy-loop)
+pkill -f "open-tag/node_modules.*tsx.*src/daemon/index.ts" 2>/dev/null || true  # its tsx/node child (this checkout only; not worktrees / other repos)
 
 echo "✅ prod down (server + open-tag daemon)."


### PR DESCRIPTION
Final leftover of the fancy→open-tag rename: two comments in `scripts/prod-down.sh` named the internal `fancy-loop` repo as an example. open-tag is public, so genericize to match `prod-up.sh` ("a separate repo" / "other repos"). Comment-only, no behavior change.

Verified: full-repo `grep -i fancy` now returns zero (only the `fancyboi999` GitHub username remains); `bash -n` OK.