### PR TITLE
chore(workflow): default to worktree dev + soft main-checkout reminder hook

### DIFF
--- a/.claude/hooks/worktree-reminder.sh
+++ b/.claude/hooks/worktree-reminder.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# PreToolUse (Edit|Write) soft reminder — see AGENTS.md "Parallel development (worktrees)".
+# Nudges toward `npm run wt:add` when editing on `main` in the MAIN checkout. Fires once per
+# session. NEVER blocks (always exits 0); stays silent inside a worktree or on a non-main branch.
+# Intentionally a reminder, not a gate — trivial doc/one-line edits on a main-checkout branch are fine.
+input="$(cat)"
+
+# Only act inside a git work tree.
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# Silent inside a linked worktree (its git-dir lives under .../​.git/worktrees/<name>).
+case "$(git rev-parse --git-dir 2>/dev/null)" in
+  */worktrees/*) exit 0 ;;
+esac
+
+# Silent unless on the default branch `main`.
+[ "$(git branch --show-current 2>/dev/null)" = "main" ] || exit 0
+
+# Once per session: dedupe on the hook's session_id (parsed without jq — may be absent on macOS).
+sid="$(printf '%s' "$input" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+marker="${TMPDIR:-/tmp}/claude-wt-reminder-${sid:-default}"
+if [ -e "$marker" ]; then exit 0; fi
+: > "$marker" 2>/dev/null || true
+
+# Non-blocking: inject a reminder into the model's context (no permissionDecision = proceed).
+cat <<'JSON'
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"open-tag worktree reminder: you're editing on `main` in the MAIN checkout. Default workflow is to do non-trivial work (a feature, multi-file change, or anything needing an isolated stack) in a worktree: `npm run wt:add -- <name>` (own DB/ports/data-dir, branched from origin/main), then open the PR from there. Trivial doc / one-line changes on a branch off origin/main in the main checkout are fine — use judgment. This fires once per session."}}
+JSON
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/worktree-reminder.sh\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,14 @@ its own iterative improvement — autonomously.
 
 ## Parallel development (worktrees)
 
+- **Default workflow: do your work in a worktree, not the main checkout.** Start any
+  **feature, multi-file change, or task that needs an isolated stack** (agent runtime,
+  realtime, DB) with `npm run wt:add -- <name>`, and open the PR from there. The main
+  checkout stays on `main` (it's where prod runs). **Exception — trivial changes**
+  (a doc edit, a one/two-line fix) may use a plain branch off `origin/main` in the main
+  checkout; use judgment, don't spin up a worktree's whole DB+seed for a typo. A soft,
+  non-blocking reminder fires once per session when you edit on `main` in the main checkout
+  (`.claude/hooks/worktree-reminder.sh`, wired in `.claude/settings.json`).
 - Use `npm run wt:add -- <name>` to spin up an isolated git worktree (its own ports +
   `opentag_<name>` database + redis index + **`OPEN_TAG_HOME=~/.open-tag-<name>` data dir** +
   seeded data); `npm run wt:rm -- <name>` tears it down (and cleans the data dir + db). Lets


### PR DESCRIPTION
Agents weren't defaulting to worktree-based development. This makes it the **documented default** and adds a **gentle, non-blocking nudge** (you chose soft reminder over a hard gate).

- **AGENTS.md** — 'Parallel development' now leads with the default workflow: feature / multi-file / isolated-stack work goes in a worktree (`npm run wt:add`); trivial doc / one-liners may use a branch in the main checkout. Main checkout stays on `main` (prod).
- **`.claude/hooks/worktree-reminder.sh`** — `PreToolUse(Edit|Write)` hook: when editing on `main` in the MAIN checkout, injects a once-per-session reminder toward `wt:add`. **Never blocks** (always exit 0); silent inside a worktree or on a non-main branch; dedupes on `session_id`.
- **`.claude/settings.json`** — wires the hook (new checked-in file; `settings.local.json` stays gitignored).

**Verified:** pipe-tested every path (non-main → silent; main → fires; same session → deduped; new session → fires again); `jq -e` validates the hook structure; script committed executable (100755).

**Note:** the settings watcher only picks up `.claude/settings.json` after `/hooks` or a restart for sessions that started before it existed — so the hook activates for **new** sessions (which is the point). Not a code change; CI is docs/config only.