### PR TITLE
feat(computers): auto-close connect-machine modal once its daemon comes online

### DIFF
--- a/web/src/views/misc.tsx
+++ b/web/src/views/misc.tsx
@@ -243,17 +243,19 @@ export function Computers() {
 // Connect machine modal: generates an API key and a ready-to-run daemon connection command
 function ConnectMachineModal({ onClose }: { onClose: () => void }) {
   useEscClose(onClose);
-  const { api, serverId, reload } = useStore();
+  const { api, serverId, reload, machines } = useStore();
   const { t } = useTranslation();
   const [name, setName] = useState("");
   const [busy, setBusy] = useState(false);
-  const [res, setRes] = useState<{ key: string; name: string } | null>(null);
+  const [res, setRes] = useState<{ id: string; key: string; name: string } | null>(null);
   const [copied, setCopied] = useState("");
   const gen = async () => {
     setBusy(true);
-    try { const r = await api("POST", `/api/servers/${serverId}/machines`, { name: name.trim() }); if (r?.key) { setRes({ key: r.key, name: r.name }); await reload(); } }
+    try { const r = await api("POST", `/api/servers/${serverId}/machines`, { name: name.trim() }); if (r?.key) { setRes({ id: r.id, key: r.key, name: r.name }); await reload(); } }
     finally { setBusy(false); }
   };
+  // Auto-close once the just-added machine's daemon comes online (store refetches machines on the machine:status socket event).
+  useEffect(() => { if (res && machines.some((m) => m.id === res.id && m.status === "online")) onClose(); }, [machines, res, onClose]);
   const cmd = res ? `npx @fancyboi999/open-tag-daemon --server-url ${window.location.origin} --api-key ${res.key}` : "";
   const copy = (text: string, tag: string) => { navigator.clipboard?.writeText(text); setCopied(tag); setTimeout(() => setCopied(""), 1500); };
   return (


### PR DESCRIPTION
## What

The **Connect a Machine** modal shows the generated `sk_machine_*` key + the
one-click `npx` command, then waited for a manual **Done** click. Now it
**auto-closes the instant the just-added machine's daemon comes online**, so
after the user runs the command on the target host the flow finishes
hands-free.

## How (8 lines, `web/src/views/misc.tsx` only)

- Capture the new machine's `id` from the POST response (`POST
  /api/servers/:id/machines` already returns `id` — it just wasn't captured).
- `useEffect` calls `onClose()` when that machine flips to `status === "online"`.
  The store **already** refetches `machines` on the `machine:status` socket
  event (`store.tsx`), so no new realtime plumbing is needed.

Manual close paths (Cancel / Done / Esc / backdrop) are untouched — this only
**adds** an effect that calls the same `onClose`.

## Verification (real E2E, isolated worktree)

- `npm run typecheck` (root + web) — green
- `npm run web:build` — clean
- **Browser E2E**: dev-login → Computers → **+** → generate key (machine row
  created `offline`, modal stays open) → ran a **real daemon** with that key →
  daemon `ready` (7 runtimes) → machine flipped **online** → **modal
  auto-closed**. Verified via before/after DOM snapshots + screenshots.

## Doc-sync

No schema / route / daemon-protocol / module-boundary / contract change — this
is a UX micro-enhancement inside an existing flow, so no doc update required.