### PR TITLE
[codex] fix agent activity panel scroll position

### DIFF
--- a/test/profileActivityScrollLayout.unit.test.ts
+++ b/test/profileActivityScrollLayout.unit.test.ts
@@ -1,0 +1,34 @@
+// Unit regression for embedded agent profile layout.
+// Run: npx tsx --test --test-force-exit test/profileActivityScrollLayout.unit.test.ts
+//
+// The chat right-column profile panel hosts AgentProfile(Activity). The visible activity history
+// must scroll inside the tab body, not on the outer aside; otherwise opening the panel starts at
+// the profile header and ActivityTab's auto-scroll writes to a non-scrolling inner node.
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const css = fs.readFileSync(new URL("../web/src/styles.css", import.meta.url), "utf8");
+
+function ruleBody(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const m = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`).exec(css);
+  assert.ok(m, `missing CSS rule for ${selector}`);
+  return m[1]!;
+}
+
+function assertDecl(body: string, prop: string, value: string): void {
+  assert.match(body, new RegExp(`${prop}\\s*:\\s*${value}(?:;|$)`), `expected ${prop}:${value} in:\n${body}`);
+}
+
+test("embedded profile panel keeps the outer aside fixed and scrolls only the active tab body", () => {
+  const profileMode = ruleBody("aside.traj-col.profile-mode");
+  assertDecl(profileMode, "display", "flex");
+  assertDecl(profileMode, "flex-direction", "column");
+  assertDecl(profileMode, "overflow", "hidden");
+
+  const profileBody = ruleBody("aside.traj-col.profile-mode .scroll");
+  assertDecl(profileBody, "flex", "1");
+  assertDecl(profileBody, "min-height", "0");
+  assertDecl(profileBody, "overflow", "auto");
+});

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -573,7 +573,8 @@ aside.traj-col .ptabs{display:flex;gap:2px;overflow-x:auto;border-bottom:1px sol
 aside.traj-col .ptabs::-webkit-scrollbar{display:none}
 aside.traj-col .ptabs button{flex:none;font-size:12px;padding:4px 9px;border:0;background:transparent;color:var(--muted);cursor:pointer;border-radius:8px;white-space:nowrap}
 aside.traj-col .ptabs button.on{background:var(--surface-strong);color:var(--ink)}
-aside.traj-col .scroll{padding:0;margin:0 -20px;padding:0 20px}
+aside.traj-col.profile-mode{display:flex;flex-direction:column;overflow:hidden;min-height:0}
+aside.traj-col.profile-mode .scroll{flex:1;min-height:0;overflow:auto;margin:0 -20px;padding:0 20px}
 
 /* ── Hover agent → info card ─────────────────────────── */
 .agent-hovercard{position:fixed;z-index:60;display:flex;gap:11px;align-items:flex-start;background:var(--surface);border:1px solid var(--hair-strong);border-radius:12px;box-shadow:0 8px 28px var(--shadow-3);padding:13px 15px;min-width:200px;max-width:248px;pointer-events:none;animation:ahc-in .12s cubic-bezier(.22,1,.36,1)}


### PR DESCRIPTION
## Summary

- Fixes the embedded agent profile Activity panel so the activity history scrolls inside the tab body instead of the outer right-column aside.
- Keeps the profile header and tabs fixed while the Activity tab opens at the newest activity entry.
- Adds a regression test that pins the layout contract for the chat right-column profile panel.

## Root cause

The chat right-column profile overlay is rendered inside `aside.traj-col.profile-mode`, but on desktop it inherited the normal live-trace aside behavior: the outer aside was the scroll container. `ActivityTab` already tried to set `scrollTop = scrollHeight`, but it was writing to its inner `.scroll` node. In the embedded profile layout that inner node was not the effective scroll container, so entering the Activity panel could show the profile/header/top of the activity list instead of the latest entries.

## Validation

- `npm run typecheck`
- `npx tsx --test --test-force-exit test/trajBuffer.unit.test.ts test/profileActivityScrollLayout.unit.test.ts`
- Browser verification on an isolated worktree stack:
  - server: `PORT=7812 npm run server`
  - web: `PORT=7812 VITE_PORT=5312 npm --prefix web run dev -- --host 127.0.0.1`
  - seeded `activitybot` with 150 activity rows in the isolated worktree DB
  - opened `/s/open-tag/channel/...`, clicked the LiveAgentBar agent, and inspected the real DOM metrics:
    - `aside.traj-col.profile-mode`: `display=flex`, `overflow=hidden`, `scrollTop=0`
    - activity `.scroll`: `overflow=auto`, `scrollTop≈5574.5`, `scrollHeight=6298`, `clientHeight=724`
    - latest visible row: `command row 150`
    - first loaded row was not visible

## Notes

The project guide prefers chrome-devtools MCP for browser verification. That MCP surface was not exposed in this Codex turn, so I used the in-app Browser plugin against localhost and recorded DOM metrics plus a screenshot-equivalent visual check instead.
