### PR TITLE
fix(web): render offline status dot in DM sidebar

### DIFF
--- a/web/src/views/ChatSidebar.tsx
+++ b/web/src/views/ChatSidebar.tsx
@@ -66,7 +66,7 @@ export function ChatSidebar() {
         return (
         <button key={c.id} className={"item" + (c.id === channelId ? " active" : "")} onClick={() => nav(`/s/${slug}/channel/${c.id}`)}>
           <Avatar seed={c.peerDisplayName || c.peerName || c.peerId || c.id} url={avFor(c.peerAvatarUrl)} size={20} /><span className="grow">{c.peerDisplayName || c.peerName || t("sidebar.unknownUser")}</span>
-          {a?.activity && a.activity !== "offline" && <span className={"dot " + a.activity} title={a.activityDetail || a.activity} />}
+          {a && <span className={"dot " + (a.activity || "offline")} role="img" aria-label={t("members.statusLabel", { status: a.activity || "offline" })} title={a.activityDetail || a.activity || "offline"} />}
           {!!unread[c.id] && <span className="badge">{unread[c.id]}</span>}
         </button>
         );


### PR DESCRIPTION
## What & why

In the DM sidebar, an offline agent showed **no dot at all** — a blank gap, no tooltip — indistinguishable from "status not loaded yet".

Root cause: `ChatSidebar.tsx` was the **only** place that special-cased offline and skipped rendering:

```tsx
{a?.activity && a.activity !== "offline" && <span className={"dot " + a.activity} ... />}
```

Everywhere else (`Chat.tsx` DM header, `Members.tsx` member list, `misc.tsx` machine panel) already renders a gray `.dot.offline`. The gray style has existed in `styles.css:72` all along — the sidebar just filtered it out. So this is a **consistency fix**, not a new feature.

## The change (one line)

Align the DM sidebar with the most complete variant (`Members.tsx`):
- Always render the dot when the DM peer is a known agent.
- Fall back to `"offline"` when `activity` is empty (matches the DM header `Chat.tsx:229`).
- Add `role="img"` + `aria-label` — **reusing the existing `members.statusLabel` i18n key, no new copy** — and keep the hover `title`.
- Human DMs and "agent not loaded" still render no dot (unchanged — no fake status for unknown peers).

## Verification (real browser, chrome-devtools + dev-login)

| state | className | computed bg | resolves to |
|---|---|---|---|
| offline | `dot offline` | `rgb(168,162,158)` | `#a8a29e` gray ✓ |
| online  | `dot online`  | `rgb(22,163,74)`   | `#16a34a` green ✓ |

- Built the branch frontend via vite, API against the local server + DB, dev-login.
- Created a DM with an offline agent → gray dot appears with `aria-label="Status: offline"` + `title="offline"` (before the fix, the dot was absent from the DOM entirely).
- Flipped the same agent to `online` → same dot turns green, proving the `|| "offline"` fallback only kicks in when activity is empty and non-offline colors are untouched.
- `npm run typecheck` (root + web) passes.

## Note
The original report (a copilot agent showing no dot) was on a different environment; the runtime bug behind that is being handled separately. This PR fixes the **rendering** so any offline agent gets a clear gray dot regardless of cause.