### PR TITLE
fix(deploy): prod:up migrates the DB before starting the new server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ setup otherwise. Decide per task.
 
 | You changed… | Must also update |
 |---|---|
-| `src/db/schema.ts` (tables / columns) | `docs/generated/db-schema.md` |
+| `src/db/schema.ts` (tables / columns) | `docs/generated/db-schema.md` — **and the prod DB gets migrated on deploy** (`prod:up` now runs `db:push:prod`; see **Release discipline**). |
 | Routes/endpoints (`routes-api` / `routes-agent`), CLI sub-commands, daemon protocol | `ARCHITECTURE.md` codemap / boundaries / contracts |
 | Module purpose / boundary / architectural invariant | `ARCHITECTURE.md` §II–IV |
 | A feature (completed or modified) | `FEATURES.md` checkbox + `README.md` "Verified" section if relevant |
@@ -118,6 +118,13 @@ setup otherwise. Decide per task.
   plain merge / tag / push publishes nothing. (New runtime → minor bump; bugfix → patch.)
 - A long-lived daemon keeps running the **old** bundle until **restarted** — bounce it
   (`npx @fancyboi999/open-tag-daemon@latest`) on each prod machine after publishing.
+
+**Server-side: code ≠ deployed until the DB is migrated too.** A change to `src/db/schema.ts`
+(new column / index / `onConflict` target) makes the new server code expect a schema the prod DB
+may not have yet — once a merged-but-unmigrated partial unique index made agent-create 500 in prod.
+`scripts/prod-up.sh` now runs `db:push:prod` **between the web build and the server start**, so a
+normal deploy migrates the DB before the new code serves. **Don't hand-restart the prod server and
+skip it.** (`db:push` is additive-safe and prompts before any destructive change.)
 
 ## Code quality (load-bearing — full text in `docs/code-quality.md`)
 

--- a/scripts/prod-up.sh
+++ b/scripts/prod-up.sh
@@ -15,6 +15,14 @@ sleep 1
 echo "→ building web (web/dist is served by the server)…"
 npm run web:build >/dev/null
 
+# Migrate the DB schema to the code BEFORE the new server starts. Skipping this is how a prod:up
+# once shipped code whose onConflict / new columns hit a not-yet-migrated DB → runtime 500s (agent
+# create failed on a missing partial unique index added by a merged-but-unmigrated schema change).
+# drizzle-kit push is additive-safe and prompts before any destructive change; `set -e` aborts
+# prod:up if the migration fails, so the server never starts against a mismatched schema.
+echo "→ syncing DB schema to code (drizzle-kit push)…"
+npm run db:push:prod
+
 echo "→ starting server on :$PORT (background)…"
 nohup npm run start:prod > "$LOGDIR/prod-server.out" 2>&1 &
 for i in $(seq 1 40); do curl -sf "http://127.0.0.1:$PORT/health" >/dev/null 2>&1 && break; sleep 1; done


### PR DESCRIPTION
## Why

Today a server-only `prod:up` (restart to latest code, no DB migration) made **creating a cursor agent 500 in prod**:

```
ERROR: there is no unique or exclusion constraint matching the ON CONFLICT specification
```

Root cause: #55 added a partial unique index `agents_name_uniq (server_id, name) where deleted_at is null`, and the create-agent code uses `onConflictDoNothing` against it. The server was restarted onto #55's code, but `prod:up` only restarts the server + rebuilds web — **it never migrated the DB**, so the index wasn't there and every `onConflict` insert threw. (Fixed live by creating the index by hand; this PR stops it recurring.)

`merged ≠ deployed` had a second half we hadn't covered: not just "daemon npm package must be published", but **"prod DB must be migrated to match the new server code"**.

## What

- **`scripts/prod-up.sh`** — runs `npm run db:push:prod` **between the web build and the server start**, so a normal deploy migrates the DB before the new code serves. `drizzle-kit push` is additive-safe and prompts before destructive changes; `set -e` aborts the deploy if migration fails (server never starts against a mismatched schema).
- **`AGENTS.md`** — doc-sync schema row + Release discipline now state that a `schema.ts` change isn't deployed until the prod DB is migrated, and that `prod:up` now does it.

## Verification

- `bash -n scripts/prod-up.sh` — syntax OK.
- `db:push:prod` against current prod → **`No changes detected`** (prod schema already matches code after the hand-fix), so the new step is a safe no-op today and will carry future schema changes automatically.
- Cross-server duplicate agent names checked = none, so the step won't trip on the redundant single-col `.unique()` in schema.ts:10 (separate cleanup, not in this PR).
