### PR TITLE
fix(web): keep workspace-switcher create row inside the popover

### DIFF
--- a/test/swCreateOverflow.unit.test.ts
+++ b/test/swCreateOverflow.unit.test.ts
@@ -1,0 +1,35 @@
+// Unit regression for the workspace-switcher "create workspace" row layout.
+// Run: npx tsx --test --test-force-exit test/swCreateOverflow.unit.test.ts
+//
+// The switcher popover (.sw-pop) is a fixed 230px-wide box. The create row (.sw-create) is a
+// flex row holding a text <input> (flex:1) + a "Create" button (.sw-go). A flex <input> defaults
+// to min-width:auto, whose intrinsic min size (driven by the input's `size` attr) is wider than
+// the available track — so flex:1 can't shrink it and the row overflows the popover's right edge.
+// Pinning the input to min-width:0 lets flex:1 actually shrink it to fit the container.
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const css = fs.readFileSync(new URL("../web/src/styles.css", import.meta.url), "utf8");
+
+function ruleBody(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const m = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`).exec(css);
+  assert.ok(m, `missing CSS rule for ${selector}`);
+  return m[1]!;
+}
+
+function assertDecl(body: string, prop: string, value: string): void {
+  assert.match(body, new RegExp(`${prop}\\s*:\\s*${value}(?:;|$)`), `expected ${prop}:${value} in:\n${body}`);
+}
+
+test("workspace-switcher create row keeps its input shrinkable so it never overflows the popover", () => {
+  const row = ruleBody(".sw-create");
+  assertDecl(row, "display", "flex");
+
+  const input = ruleBody(".sw-create input");
+  assertDecl(input, "flex", "1");
+  // The fix: without min-width:0 the flex input refuses to shrink below its intrinsic size and
+  // pushes the Create button past .sw-pop's right edge.
+  assertDecl(input, "min-width", "0");
+});

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -41,7 +41,7 @@ button{font-family:inherit}
 .sw-add{display:flex;align-items:center;gap:7px;width:100%;border:0;border-top:1px solid var(--hair);background:transparent;cursor:pointer;padding:9px 8px 5px;margin-top:5px;color:var(--muted);font-size:13px}
 .sw-add:hover{color:var(--ink)}
 .sw-create{display:flex;gap:6px;margin-top:6px;padding:2px}
-.sw-create input{flex:1;font-size:13px;padding:6px 9px;border:1px solid var(--hair-strong);border-radius:8px;outline:none;background:var(--canvas);color:var(--ink);font-family:inherit}
+.sw-create input{flex:1;min-width:0;font-size:13px;padding:6px 9px;border:1px solid var(--hair-strong);border-radius:8px;outline:none;background:var(--canvas);color:var(--ink);font-family:inherit}
 .sw-go{font-size:13px;color:var(--on-ink);background:var(--ink-2);border:0;padding:6px 12px;border-radius:8px;cursor:pointer}
 .rail a.t{width:40px;height:40px;border-radius:12px;border:1px solid transparent;background:transparent;color:var(--muted);display:flex;align-items:center;justify-content:center;cursor:pointer;text-decoration:none}
 .rail a.t:hover{background:var(--surface-strong);color:var(--ink)}


### PR DESCRIPTION
## What

The workspace-switcher popover's "create workspace" row overflowed the popover's right edge — the `Workspace name` input + `Create` button spilled outside the rounded container (see the reported screenshot).

## Root cause

`.sw-pop` is a fixed **230px** popover (padding 7px, border 1px). Its create row `.sw-create` is `display:flex` with a text `<input>` (`flex:1`) + a `Create` button (`.sw-go`).

A flex `<input>` defaults to **`min-width:auto`**, whose *intrinsic* minimum width (driven by the input's `size` attribute, ~170px+) is **wider than the available track**. The flex algorithm refuses to shrink a flex item below its `min-width`, so `flex:1` couldn't compress the input — and the whole row (input + gap + button) pushed the `Create` button past the popover's content box.

## Fix

One line — pin the input to `min-width:0` so `flex:1` can actually shrink it to fit:

```css
.sw-create input{flex:1;min-width:0; …}
```

Scoped to `.sw-create input` only — no logic change in `ServerSwitcher.tsx`, no other `.sw-*` element touched.

## Evidence

**Real-browser measurement** (running app, isolated chrome-devtools, popover content-box right edge = `popover.right − border − padding`):

| State | input `min-width` | `Create` button vs content-box right |
|---|---|---|
| before (bug) | `auto` (flex default) | **+94.6px past** → overflows |
| after (fix) | `0` | **−2px inside** → contained |

**Regression test** — `test/swCreateOverflow.unit.test.ts` (node:test, reads `styles.css`):
- Passes with the fix ✅
- **Tautology-checked**: removing `min-width:0` makes it **fail** for the stated reason ✅
- Run: `npx tsx --test --test-force-exit test/swCreateOverflow.unit.test.ts`

**Other checks**: `npm run typecheck` (root + web) clean ✅. An independent skeptical verifier reproduced the before/after measurement in an isolated browser and attacked the edges — long (50-char) workspace names don't push the button out, no bleed onto other `.sw-*` elements, narrow-viewport breakpoint hides `.sw-wrap` entirely (no new issue), and the shrunk input stays ~104px wide (usable). Verdict: PASS.

Screenshots captured locally (before: button overflowing; after: contained) — GitHub doesn't allow embedding images via the `gh` CLI, so they live at `.shots/sw-before-overflow.png` / `.shots/sw-after-fixed.png` in the dev environment.

## Doc-sync

None required — pure CSS bugfix; no schema / route / module-boundary / feature-list change. `ARCHITECTURE.md:94` only names `ServerSwitcher.tsx`'s existence (unaffected).

## Fail-loud (what was NOT verified)

- The regression regex is value-exact for `min-width:0` (won't match a `0px` reformat) — a *false-fail* risk if someone reformats, never a false-pass; left as-is since unitless `0` is this file's convention.
- Did not exercise an actual `Create` submission (the bug was purely visual / layout).
- Single Chromium engine only — no Firefox/Safari or non-default zoom / font-scaling check.
