### PR TITLE
Fix task status label translation in chat

### DIFF
--- a/web/src/views/Chat.tsx
+++ b/web/src/views/Chat.tsx
@@ -318,10 +318,10 @@ export function Chat() {
                           return (
                             <span className="task-pill-wrap">
                               {/* clicking the badge changes status (does not open thread; use the reply / thread button for that) */}
-                              <button className={"task-pill st-" + m.taskStatus} onClick={(e) => { e.stopPropagation(); setTaskMenu(open ? null : m.id); }} title={t("chat.taskChangeStatus", { number: m.taskNumber })}><TI size={11} /> #{m.taskNumber} {ST_LABEL[m.taskStatus] ?? m.taskStatus}{taskAssignee(m)}</button>
+                              <button className={"task-pill st-" + m.taskStatus} onClick={(e) => { e.stopPropagation(); setTaskMenu(open ? null : m.id); }} title={t("chat.taskChangeStatus", { number: m.taskNumber })}><TI size={11} /> #{m.taskNumber} {t(ST_LABEL[m.taskStatus] ?? m.taskStatus)}{taskAssignee(m)}</button>
                               {open && <div className="st-menu" onMouseLeave={() => setTaskMenu(null)}>
                                 {claimable && <button onClick={() => { setTaskMenu(null); doTask(m, "claim"); }}>{t("chat.claim")}</button>}
-                                {opts.map((s) => <button key={s} className={s === m.taskStatus ? "on" : ""} onClick={() => { setTaskMenu(null); if (s !== m.taskStatus) doTask(m, "status", { status: s }); }}><span className={"st-dot st-" + s} />{ST_LABEL[s]}</button>)}
+                                {opts.map((s) => <button key={s} className={s === m.taskStatus ? "on" : ""} onClick={() => { setTaskMenu(null); if (s !== m.taskStatus) doTask(m, "status", { status: s }); }}><span className={"st-dot st-" + s} />{t(ST_LABEL[s])}</button>)}
                               </div>}
                             </span>
                           );


### PR DESCRIPTION
Summary:
- Translate task status labels in chat task badges
- Translate task status labels in the chat badge status menu

Why:
The task board already renders status labels through `t(...)`, but chat message task badges render `ST_LABEL[...]` directly. That exposes i18n keys such as `tasks.statusInReview` instead of user-facing labels like `In Review` or `待审阅`.

Test Plan:
- `npm run web:build`