### PR TITLE
Add fallback for invite link copy

### DIFF
--- a/web/src/views/misc.tsx
+++ b/web/src/views/misc.tsx
@@ -566,6 +566,36 @@ export function Saved() {
 }
 
 // Invite members (join-links): owner/admin generates invite links (configurable role/max-uses) → share → recipient registers or logs in to join.
+async function copyText(text: string): Promise<boolean> {
+  if (navigator.clipboard && window.isSecureContext) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall back to the textarea path below.
+    }
+  }
+
+  const el = document.createElement("textarea");
+  el.value = text;
+  el.setAttribute("readonly", "");
+  el.style.position = "fixed";
+  el.style.top = "-1000px";
+  el.style.left = "-1000px";
+  el.style.opacity = "0";
+  document.body.appendChild(el);
+  el.focus();
+  el.select();
+  el.setSelectionRange(0, text.length);
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(el);
+  }
+}
+
 function InvitesSettings({ api, serverId }: { api: any; serverId: string }) {
   const { capabilities } = useStore();
   const { t } = useTranslation();
@@ -579,7 +609,15 @@ function InvitesSettings({ api, serverId }: { api: any; serverId: string }) {
   const create = async () => { await api("POST", `/api/servers/${serverId}/join-links`, { role, maxUses: maxUses ? Number(maxUses) : null }); setMaxUses(""); load(); };
   const del = async (id: string) => { await api("DELETE", `/api/servers/${serverId}/join-links/${id}`); load(); };
   const urlOf = (tok: string) => `${location.origin}/join/${tok}`;
-  const copy = async (tok: string) => { try { await navigator.clipboard.writeText(urlOf(tok)); setCopied(tok); setTimeout(() => setCopied(""), 1500); } catch { /* */ } };
+  const copy = async (tok: string) => {
+    const link = urlOf(tok);
+    if (await copyText(link)) {
+      setCopied(tok);
+      setTimeout(() => setCopied(""), 1500);
+    } else {
+      window.prompt(t("members.copyLink"), link);
+    }
+  };
   return (
     <div className="setform">
       <label>{t("misc.invitesLabel")}</label>


### PR DESCRIPTION
## Summary

- Add a fallback path for copying invite links when `navigator.clipboard` is unavailable or blocked
- Show a prompt as a final fallback so users can still manually copy the generated invite URL

## Why

Self-hosted deployments are often first accessed over plain HTTP, such as `http://<ip>:<port>`. In that context, browsers may reject `navigator.clipboard.writeText(...)`, leaving the clipboard unchanged. The invite modal should still make the generated link copyable.

## Test Plan

- `npm run web:build`