### PR TITLE
chore(deps): tune dependabot to stop major-bump noise + take safe CI action bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,40 @@
 version: 2
+# Tuned to avoid noise: patch/minor only (majors are upgraded deliberately, after
+# real testing — Dependabot's CI green ≠ runtime-safe for a major lib bump), grouped
+# into one PR per ecosystem, with a cap on concurrently-open PRs.
 updates:
   # Root package (server + daemon + CLI)
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      root-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # Web frontend (Vite + React)
   - package-ecosystem: "npm"
     directory: "/web"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      web-minor-patch:
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
-  # GitHub Actions workflows
+  # GitHub Actions workflows (grouped; action majors are low-risk CI infra)
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
   typecheck-and-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 


### PR DESCRIPTION
Dependabot (added by #79) opened 11 PRs on first scan — mostly **major** version bumps that CI green can't vouch for at runtime. This tunes it:

- **npm (root + /web): ignore `semver-major`** — majors are upgraded deliberately, after real testing (a green typecheck/build/unit-test run does NOT prove a major lib bump is runtime-safe, e.g. react-router 6→7, zod 3→4).
- **Group** minor/patch into one PR per ecosystem; **`open-pull-requests-limit: 5`** — no more 11-PR floods.
- **github-actions:** grouped. Folds in the two safe action bumps directly: `actions/checkout@v4→v7`, `actions/setup-node@v4→v6` (both were green as #80/#81).

The 11 auto-opened PRs (#80–#90) are being closed: action bumps are folded here; the npm majors are deferred to deliberate tested upgrades.