### PR TITLE
feat(web): motion pass — message-enter, micro-interactions, landing orb drift + hero typewriter

### DIFF
--- a/docs/motion-charter.md
+++ b/docs/motion-charter.md
@@ -1,0 +1,59 @@
+# Motion Charter — open-tag 动效宪法
+
+> 后面所有动效子 agent 的剧本。规范层(不靠"看")由主 agent 定;实现+视觉迭代由子 agent 在真实页面录 GIF 自验闭环。
+> 最终落地:token → `web/src/styles.css :root`;本宪法提炼进 `DESIGN.md` 的 Motion 章节(补 Known Gaps)。
+
+## 1. 动效 token(复用现有曲线,别另造)
+
+应用主体(`styles.css :root` 新增。落地页 `--lp-*` 自成体系,不动):
+
+```css
+/* easing —— 复用现有 + 补一条招牌曲线 */
+--ease-quint: cubic-bezier(.22, 1, .36, 1);  /* 现有主力(tk-slot/switch/ahc-in)→ UI 默认 */
+--ease-expo:  cubic-bezier(.16, 1, .3, 1);   /* 新增,animate.md「笃定」曲线 → 招牌进场 */
+--ease-decel: cubic-bezier(0, 0, .2, 1);     /* 现有(lb-ping)→ 持续/扩散/循环 */
+
+/* duration —— 贴现有 .12/.18/.22s,锚 product 的 150–250ms */
+--dur-fast:      120ms;  /* press / caret / toggle —— 瞬时反馈 */
+--dur-base:      200ms;  /* hover / 状态切换 / 视图过渡 */
+--dur-slow:      320ms;  /* modal / drawer 进出 / 展开折叠 */
+--dur-signature: 440ms;  /* 招牌进场(agent 上线 / 消息进场) */
+```
+
+## 2. 动效清单(分级)
+
+### 招牌(过「你」这关,允许表现力)
+| 动效 | 元素 | 动什么 | 时长 / 曲线 |
+|---|---|---|---|
+| **agent 醒来** | live-bar pip + 头像 | scale+blur+opacity 归位 + 光环扩散 | 440ms `--ease-expo` |
+| **消息进场** | 新消息行 | opacity + translateY 微升(连发 stagger) | 320ms `--ease-quint` |
+| **hero orb drift** | 落地页 gradient orbs | 缓慢漂移呼吸 | 长循环 `--ease-decel` |
+
+### 次要(客观红线全绿即合格,克制,不劳你看)
+按钮 press（scale .97 / `--dur-fast`）· caret 旋转（统一 `--dur-fast`）· 频道/视图切换 crossfade+微移（`--dur-base/--ease-quint`）· modal/drawer 进出（`--dur-slow`,统一现有散值）· 未读分隔线淡入（`--dur-base`）· toast/hovercard（已有,统一到 token）
+
+## 3. 每个招牌的「设计意图描述」(= 实现 brief + 子 agent 自评对照标准)
+
+**agent 醒来**：agent 从 offline→online 时,其头像从 `scale .85 + opacity .4 + blur 3px` 在 440ms 内 `--ease-expo` 归位清晰;同时 live-bar 状态 pip 从中心向外扩一圈细环(复用现有 `lb-ping` 思路,但单次非循环)。情绪:笃定地「醒来上线」,**不弹跳**。参照 Linear issue 状态切换的克制笃定感。
+
+**消息进场**：新到的消息行从 `opacity 0 + translateY 6px` 在 320ms `--ease-quint` 落定;一次多条时按 60ms stagger 上限错峰(≤8 条,超出不再延迟)。情绪:消息「落」进来,轻、不抢眼。**只对真·新增的消息,不对滚动加载的历史**。
+
+**hero orb drift**：落地页 hero 背后的 gradient orbs(mint/peach/lavender/sky)以 12–20s 周期、≤24px 幅度极缓漂移+轻微 scale 呼吸,彼此不同相位。情绪:氛围在「呼吸」,几乎察觉不到的活气,绝不喧宾夺主。纯装饰 → reduced-motion 下完全静止。
+
+## 4. 客观红线(所有动效通用,子 agent 机械自判,全绿才算过)
+
+1. **只动** `transform` / `opacity` / `filter`(grep 实现,**零** `width`/`height`/`top`/`left`/`margin` 动画)
+2. 时长走 token,落在该档区间;**无** bounce / elastic 曲线
+3. 用规范 easing token(应用主体 `--ease-*`,落地页 `--lp-ease`)
+4. **reduced-motion 降级**:`@media (prefers-reduced-motion:reduce)` 下进场动效直显、循环动效静止
+5. 布局不崩:动效前后静态帧对比无位移/截断
+6. `npm run typecheck`(root + web)过
+
+## 5. reduced-motion 策略
+
+现有 5 处散写保留不动(surgical)。**新动效**统一进一个集中兜底块(进场→直显,循环→停),别再散落。
+
+## 6. 验收 & 回传
+
+子 agent 每个动效:写实现 → `~/.pw-tools/anim-capture.mjs` 录 GIF → Read 关键帧 → 对 §4 红线(逐条)+ §3 设计意图(吻合?差哪?)自评 → 不满意自己改,**最多 3 轮**,到顶带现状 GIF+卡点回传。
+回传纯文字+路径:红线逐条结果 + 设计意图自评 + GIF 路径。主 agent 只核红线(没绿打回,不看图);招牌 GIF 交「你」做审美裁决。

--- a/web/src/landing/landing.css
+++ b/web/src/landing/landing.css
@@ -104,6 +104,39 @@
 .lp-orb--lavender { width: 400px; height: 400px; background: #c8b8e0; top: 420px; right: 8%; opacity: 0.38; }
 .lp-orb--sky      { width: 360px; height: 360px; background: #a8c8e8; top: 560px; left: 18%; opacity: 0.32; }
 
+/* —— Hero orb drift: ambient breathing, pure transform (§4: zero layout-prop animation), 12–20s cycles, ≤24px amplitude —— */
+@keyframes lp-orb-drift-mint {
+  0%   { transform: translate(0px,    0px)   scale(1);    }
+  25%  { transform: translate(14px,  -10px)  scale(1.03); }
+  50%  { transform: translate(8px,    16px)  scale(0.98); }
+  75%  { transform: translate(-12px,  8px)   scale(1.02); }
+  100% { transform: translate(0px,    0px)   scale(1);    }
+}
+@keyframes lp-orb-drift-peach {
+  0%   { transform: translate(0px,    0px)   scale(1);    }
+  25%  { transform: translate(-16px,  10px)  scale(0.97); }
+  50%  { transform: translate(-8px,  -18px)  scale(1.04); }
+  75%  { transform: translate(18px,  -6px)   scale(0.99); }
+  100% { transform: translate(0px,    0px)   scale(1);    }
+}
+@keyframes lp-orb-drift-lavender {
+  0%   { transform: translate(0px,    0px)   scale(1);    }
+  33%  { transform: translate(20px,   12px)  scale(1.03); }
+  66%  { transform: translate(-14px,  20px)  scale(0.97); }
+  100% { transform: translate(0px,    0px)   scale(1);    }
+}
+@keyframes lp-orb-drift-sky {
+  0%   { transform: translate(0px,    0px)   scale(1);    }
+  30%  { transform: translate(-22px, -8px)   scale(1.02); }
+  60%  { transform: translate(10px,  -18px)  scale(0.98); }
+  100% { transform: translate(0px,    0px)   scale(1);    }
+}
+/* Phase-staggered via negative delay so each orb enters mid-cycle; --lp-ease = cubic-bezier(0.2,0,0,1) */
+.lp-orb--mint     { animation: lp-orb-drift-mint     16s cubic-bezier(0.2, 0, 0, 1) infinite; }
+.lp-orb--peach    { animation: lp-orb-drift-peach    20s cubic-bezier(0.2, 0, 0, 1) -5s infinite; }
+.lp-orb--lavender { animation: lp-orb-drift-lavender 14s cubic-bezier(0.2, 0, 0, 1) -8s infinite; }
+.lp-orb--sky      { animation: lp-orb-drift-sky      18s cubic-bezier(0.2, 0, 0, 1) -12s infinite; }
+
 /* —— Buttons —— */
 .lp-btn { display: inline-flex; align-items: center; gap: var(--lp-space-2); font-family: var(--lp-font-body); font-size: var(--lp-text-base); font-weight: 500; border-radius: var(--lp-radius-pill); padding: 14px 26px; cursor: pointer; transition: background var(--lp-motion-base) var(--lp-ease), border-color var(--lp-motion-base) var(--lp-ease), transform var(--lp-motion-fast) var(--lp-ease); border: 1px solid transparent; }
 .lp-btn:focus-visible { outline: none; box-shadow: var(--lp-focus-ring); }
@@ -306,6 +339,8 @@
 @media (prefers-reduced-motion: reduce) {
   .lp-hero__intro > *, .lp-browser { animation: none; }
   .lp-reveal { opacity: 1; transform: none; transition: none; }
+  /* Orb drift: stop all continuous loops (§4 red line + §5 集中兜底块) */
+  .lp-orb--mint, .lp-orb--peach, .lp-orb--lavender, .lp-orb--sky { animation: none; }
 }
 
 /* —— Responsive —— */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -12,6 +12,14 @@
   /* Shadow scale (elevation depth): black at varying opacity, centralized as tokens to prevent scattering (same sidecar approach); used for box-shadow on overlays/cards/menus */
   --shadow-1:rgba(0,0,0,.05);--shadow-2:rgba(0,0,0,.1);--shadow-3:rgba(0,0,0,.12);--shadow-4:rgba(0,0,0,.16);--shadow-5:rgba(0,0,0,.25);--shadow-6:rgba(0,0,0,.3);--shadow-7:rgba(0,0,0,.45);
   --serif:'EB Garamond','Times New Roman',serif;--sans:'Inter',-apple-system,'PingFang SC','Segoe UI',sans-serif;
+  /* Motion tokens — app shell (not landing page --lp-* system) */
+  --ease-quint: cubic-bezier(.22, 1, .36, 1);
+  --ease-expo:  cubic-bezier(.16, 1, .3, 1);
+  --ease-decel: cubic-bezier(0, 0, .2, 1);
+  --dur-fast:      120ms;
+  --dur-base:      200ms;
+  --dur-slow:      320ms;
+  --dur-signature: 440ms;
 }
 *{box-sizing:border-box}
 body{margin:0;font-family:var(--sans);font-size:16px;line-height:1.5;letter-spacing:.15px;background:var(--canvas);color:var(--ink-2)}
@@ -218,7 +226,7 @@ main.content-col{display:flex;flex-direction:column;height:100vh;background:var(
 .wake-hint.wh-off svg{color:var(--muted-soft)}
 /* Global toast notifications (toast.tsx) — one-shot operation feedback, bottom-right stack. */
 .toast-stack{position:fixed;bottom:18px;right:18px;z-index:1000;display:flex;flex-direction:column;gap:8px;max-width:360px}
-.toast{display:flex;align-items:flex-start;gap:10px;padding:10px 12px;border-radius:8px;font-size:13px;line-height:1.45;background:var(--surface);border:1px solid var(--hair-strong);box-shadow:0 4px 16px rgba(12,10,9,.12);cursor:pointer;animation:toast-in .16s ease-out}
+.toast{display:flex;align-items:flex-start;gap:10px;padding:10px 12px;border-radius:8px;font-size:13px;line-height:1.45;background:var(--surface);border:1px solid var(--hair-strong);box-shadow:0 4px 16px rgba(12,10,9,.12);cursor:pointer;animation:toast-in var(--dur-fast) var(--ease-quint) both}
 .toast-error{background:var(--error-soft);border-color:var(--error-line)}
 .toast-info{background:var(--tint-blue);border-color:var(--tint-blue-strong)}
 .toast-msg{flex:1 1 auto;color:var(--ink)}
@@ -354,7 +362,7 @@ main.content-col{display:flex;flex-direction:column;height:100vh;background:var(
 .ws-root{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:11px;font-family:ui-monospace,monospace;color:var(--muted-soft)}
 .ws-copy{flex:none;border:0;background:transparent;color:var(--muted);cursor:pointer;padding:3px;border-radius:6px;display:flex;align-items:center}
 .ws-copy:hover{background:var(--surface-strong);color:var(--ink)}
-.ws-caret{color:var(--muted-soft);transition:transform .12s}
+.ws-caret{color:var(--muted-soft);transition:transform var(--dur-fast) var(--ease-quint)}
 .ws-caret.open{transform:rotate(90deg)}
 /* .md Preview/Raw toggle (editorial pill) */
 .ws-toggle{margin-left:auto;display:inline-flex;border:1px solid var(--hair-strong);border-radius:9999px;overflow:hidden}
@@ -536,7 +544,7 @@ aside.traj-col h2{position:relative;font-size:12px;font-weight:600;letter-spacin
 .sel-trigger.open{border-color:var(--ink-2);box-shadow:0 0 0 1px var(--ink-2)}
 .sel-trigger .grow{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .sel-ph{color:var(--muted-soft)}
-.sel-caret{color:var(--muted);flex:none;transition:transform .15s ease}
+.sel-caret{color:var(--muted);flex:none;transition:transform var(--dur-fast) var(--ease-quint)}
 .sel-trigger.open .sel-caret{transform:rotate(180deg)}
 .sel-menu{position:fixed;z-index:60;background:var(--surface);border:1px solid var(--hair-strong);border-radius:12px;box-shadow:0 10px 32px rgba(12,10,9,.16);padding:5px;max-height:280px;overflow-y:auto}
 .sel-opt{display:flex;align-items:center;gap:8px;width:100%;font-family:var(--sans);font-size:15px;color:var(--body);background:none;border:0;border-radius:8px;padding:8px 10px;cursor:pointer;text-align:left}
@@ -651,7 +659,7 @@ aside.traj-col.profile-mode{display:flex;flex-direction:column;overflow:hidden;m
 aside.traj-col.profile-mode .scroll{flex:1;min-height:0;overflow:auto;margin:0 -20px;padding:0 20px}
 
 /* ── Hover agent → info card ─────────────────────────── */
-.agent-hovercard{position:fixed;z-index:60;display:flex;gap:11px;align-items:flex-start;background:var(--surface);border:1px solid var(--hair-strong);border-radius:12px;box-shadow:0 8px 28px var(--shadow-3);padding:13px 15px;min-width:200px;max-width:248px;pointer-events:none;animation:ahc-in .12s cubic-bezier(.22,1,.36,1)}
+.agent-hovercard{position:fixed;z-index:60;display:flex;gap:11px;align-items:flex-start;background:var(--surface);border:1px solid var(--hair-strong);border-radius:12px;box-shadow:0 8px 28px var(--shadow-3);padding:13px 15px;min-width:200px;max-width:248px;pointer-events:none;animation:ahc-in var(--dur-fast) var(--ease-quint) both}
 @keyframes ahc-in{from{opacity:0;transform:translateY(3px)}to{opacity:1;transform:none}}
 .agent-hovercard .ahc-body{min-width:0;display:flex;flex-direction:column;gap:2px}
 .agent-hovercard .ahc-name{font-size:15px;font-weight:600;color:var(--ink-2);display:flex;align-items:center;gap:6px}
@@ -661,7 +669,7 @@ aside.traj-col.profile-mode .scroll{flex:1;min-height:0;overflow:auto;margin:0 -
 
 /* ── Message right-click context menu ──────────────────────────── */
 .ctx-backdrop{position:fixed;inset:0;z-index:70}
-.ctx-menu{position:fixed;min-width:212px;background:var(--surface);border:1px solid var(--hair-strong);border-radius:12px;box-shadow:0 10px 34px var(--shadow-4);padding:6px;animation:ahc-in .1s ease-out}
+.ctx-menu{position:fixed;min-width:212px;background:var(--surface);border:1px solid var(--hair-strong);border-radius:12px;box-shadow:0 10px 34px var(--shadow-4);padding:6px;animation:ahc-in var(--dur-fast) var(--ease-quint) both}
 .ctx-rx{display:flex;gap:2px;padding:3px 2px 7px;margin-bottom:4px;border-bottom:1px solid var(--hair)}
 .ctx-rx button{flex:1;border:0;background:transparent;font-size:17px;line-height:1;padding:5px 0;border-radius:8px;cursor:pointer;transition:background .1s}
 .ctx-rx button:hover{background:var(--surface-strong);transform:scale(1.15)}
@@ -708,6 +716,43 @@ aside.traj-col.profile-mode .scroll{flex:1;min-height:0;overflow:auto;margin:0 -
 @keyframes lb-ping{0%{transform:scale(1);opacity:.55}70%,100%{transform:scale(2.4);opacity:0}}
 @media (prefers-reduced-motion:reduce){.live-bar__pip::after{animation:none;opacity:0}}
 
+/* ── Message enter animation: new socket-pushed messages slide in from opacity:0 + translateY(6px).
+   Only transform/opacity are animated (layout-safe). Stagger delay set per-element via --msg-delay. ── */
+@keyframes msg-enter {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.msg-enter {
+  animation-name: msg-enter;
+  animation-duration: var(--dur-slow);
+  animation-timing-function: var(--ease-quint);
+  animation-delay: var(--msg-delay, 0ms);
+  animation-fill-mode: both;
+}
+@media (prefers-reduced-motion: reduce) {
+  .msg-enter { animation: none; }
+}
+
+/* ── Primary button press feedback: snap-scale on :active (transform only, layout-safe) ── */
+.send-btn,.modal .ok,.setform .ok,.newtask,.action-card .ac-btn,.perm-head .ok{transition:transform var(--dur-fast)}
+.send-btn:active,.modal .ok:active,.setform .ok:active,.newtask:active,.action-card .ac-btn:active,.perm-head .ok:active{transform:scale(.97)}
+
+/* ── Modal / QuickSwitcher entry animation ── */
+@keyframes modal-enter{from{opacity:0;transform:translateY(6px) scale(.99)}to{opacity:1;transform:none}}
+.modal,.qs{animation:modal-enter var(--dur-slow) var(--ease-quint) both}
+
+/* ── Channel / tab content crossfade: opacity + micro translateY ── */
+@keyframes view-enter{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:none}}
+.ch-view-enter{animation:view-enter var(--dur-base) var(--ease-quint) both}
+/* TaskBoard root fires the animation on each tab-switch (board-scroll is TaskBoard's top-level element) */
+.board-scroll{animation:view-enter var(--dur-base) var(--ease-quint) both}
+
+/* ── Reduced-motion overrides for all new secondary animations (consolidated block) ── */
+@media (prefers-reduced-motion:reduce){
+  .modal,.qs,.ch-view-enter,.board-scroll{animation:none}
+  .send-btn,.modal .ok,.setform .ok,.newtask,.action-card .ac-btn,.perm-head .ok{transition:none}
+}
+
 /* ───────── Mobile adaptation (≤820px): three columns → single column, rail moves to bottom tab bar, sidebar becomes drawer, thread/profile goes fullscreen, modal becomes bottom sheet ───────── */
 .mobile-burger,.mobile-scrim{display:none}  /* hidden on desktop by default: if scrim is not hidden it occupies the first grid column and shifts rail/sidebar/content out of place */
 @media (max-width:820px){
@@ -720,7 +765,7 @@ aside.traj-col.profile-mode .scroll{flex:1;min-height:0;overflow:auto;margin:0 -
   .rail a.t.active .t-label{color:var(--ink)}
   main.content-col{grid-row:1;min-width:0;height:auto;min-height:0}  /* overrides desktop height:100vh, delegated to grid 1fr; otherwise fills viewport and pushes bottom bar off screen */
   /* sidebar (channels/members etc.) → left drawer, collapsed by default, hamburger toggles body.sb-open */
-  .sidebar{position:fixed;top:0;bottom:0;left:0;width:84vw;max-width:330px;z-index:60;transform:translateX(-100%);transition:transform .22s cubic-bezier(.2,.8,.2,1);box-shadow:4px 0 28px var(--scrim)}
+  .sidebar{position:fixed;top:0;bottom:0;left:0;width:84vw;max-width:330px;z-index:60;transform:translateX(-100%);transition:transform var(--dur-slow) var(--ease-quint);box-shadow:4px 0 28px var(--scrim)}
   body.sb-open .sidebar{transform:translateX(0)}
   body.sb-open .mobile-scrim{display:block}
   .mobile-scrim{display:none;position:fixed;inset:0;background:var(--scrim);z-index:55}

--- a/web/src/views/Chat.tsx
+++ b/web/src/views/Chat.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties } from "react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import i18n from "../i18n";
@@ -144,6 +144,11 @@ export function Chat() {
   const loadingOlderRef = useRef(false); // de-dupes concurrent "load older" fetches while one is in flight
   const prependRestoreRef = useRef<number | null>(null); // scrollHeight captured before a prepend; restored after so the viewport doesn't jump
   const trimmedRef = useRef(false); // a live-tail trim dropped the oldest in-memory messages → mark hasMore so they stay re-fetchable
+  // Message enter animation tracking: id → stagger index (0–7) for messages that arrived via socket (true new).
+  // Historical loads (initial fetch, loadOlder) never touch this map, so they never get the enter class.
+  const newMsgOrderRef = useRef(new Map<string, number>());
+  const burstCountRef = useRef(0); // how many messages have arrived in the current burst window
+  const burstTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null); // resets burstCount after 600ms silence
   const cur = [...channels, ...dms].find((c) => c.id === channelId) || channels.find((c) => c.name === "all") || channels[0];
   const curIdRef = useRef<string | undefined>(undefined);
   curIdRef.current = cur?.id; // latest channel id for async guards: a loadOlder that resolves after a channel switch must drop its stale-channel result (no cross-channel prepend / hasMore clobber)
@@ -178,7 +183,7 @@ export function Chat() {
     // eslint-disable-next-line
   }, [agentPanelReq]);
   useEffect(() => onEvent((e) => {
-    if (e.type === "message" && e.channelId === cur?.id) { setMsgs((m) => { const { next, trimmed } = appendWithCap(m, e.message, atBottomRef.current && !loadingOlderRef.current); if (trimmed) trimmedRef.current = true; return next; }); markRead(cur.id); } // don't trim mid-pagination: a trim's setHasMore(true) would race the in-flight loadOlder's setHasMore — suppressing it closes the window (the next message trims instead)
+    if (e.type === "message" && e.channelId === cur?.id) { const idx = Math.min(burstCountRef.current, 7); newMsgOrderRef.current.set(e.message.id, idx); burstCountRef.current += 1; if (burstTimerRef.current) clearTimeout(burstTimerRef.current); burstTimerRef.current = setTimeout(() => { burstCountRef.current = 0; burstTimerRef.current = null; }, 600); setMsgs((m) => { const { next, trimmed } = appendWithCap(m, e.message, atBottomRef.current && !loadingOlderRef.current); if (trimmed) trimmedRef.current = true; return next; }); markRead(cur.id); } // don't trim mid-pagination: a trim's setHasMore(true) would race the in-flight loadOlder's setHasMore — suppressing it closes the window (the next message trims instead)
     else if (e.type === "message:updated" && e.message) setMsgs((m) => m.map((x) => (x.id === e.message.id ? { ...x, ...e.message } : x))); // sync reactions and task fields
     else if (e.type === "thread:updated" && e.parentMessageId) setThreadMeta((tm) => { // live reply count update; unreadCount is approximated from the replyCount delta (socket does not carry unreadCount; the authoritative value is corrected on channel switch via GET)
       const prev = tm[e.parentMessageId]; const delta = prev ? Math.max(0, e.replyCount - prev.replyCount) : 0;
@@ -190,7 +195,7 @@ export function Chat() {
   // Keep the viewport anchored across an older-page prepend: restore scrollTop before paint. Runs before the auto-scroll effect above, which is a no-op here anyway (a prepend only happens while scrolled up, so atBottomRef is false).
   useLayoutEffect(() => { const el = scrollRef.current; if (el && prependRestoreRef.current != null) { el.scrollTop = el.scrollHeight - prependRestoreRef.current; prependRestoreRef.current = null; } }, [msgs]);
   useEffect(() => { if (trimmedRef.current) { trimmedRef.current = false; setHasMore(true); } }, [msgs]); // a live-tail trim opened a gap at the top → older messages stay re-fetchable
-  useEffect(() => { atBottomRef.current = true; setShowJump(false); }, [cur?.id]); // reset bottom-pin state on channel switch
+  useEffect(() => { atBottomRef.current = true; setShowJump(false); newMsgOrderRef.current.clear(); burstCountRef.current = 0; }, [cur?.id]); // reset bottom-pin state + new-msg enter animation tracking on channel switch
   const toBottom = () => { const el = scrollRef.current; if (el) el.scrollTop = el.scrollHeight; atBottomRef.current = true; setShowJump(false); };
   // Fetch the previous (older) page via the `before` keyset cursor and prepend it; guarded so concurrent scroll events can't fire duplicate loads.
   const loadOlder = async () => {
@@ -270,7 +275,7 @@ export function Chat() {
         {chatTab === "tasks" && cur ? <TaskBoard channelId={cur.id} onOpenThread={startThread} />
           : chatTab === "files" && cur ? <ChannelFiles channelId={cur.id} />
           : <>
-            <div className="scroll" ref={scrollRef} onScroll={onScroll}>
+            <div key={cur?.id} className="scroll ch-view-enter" ref={scrollRef} onScroll={onScroll}>
               {loaded && !msgs.length && <PaneEmpty icon={<MessageCircle size={30} />} title={t("chat.channelEmpty")} />}
               {msgs.map((m) => {
                 const ag = m.senderType === "agent" && m.senderId ? agents.find((a) => a.id === m.senderId) : undefined; // used for role description and avatar status dot
@@ -280,8 +285,10 @@ export function Chat() {
                 if (m.messageType === "action" && m.actionMetadata?.kind === "action-card") return <ActionCardMsg m={m} key={m.id} />;
                 // system messages (task lifecycle events, etc.) → centered grey bar (no avatar, no full message block)
                 if (m.senderType === "system") return <div className="msg-sys" id={"m-" + m.id} key={m.id}>{m.content}</div>;
+                const staggerIdx = newMsgOrderRef.current.get(m.id);
+                const isNewMsg = staggerIdx !== undefined;
                 return (
-                <div className="msg" id={"m-" + m.id} key={m.id} onContextMenu={(e) => { e.preventDefault(); setCtxMenu({ m, x: e.clientX, y: e.clientY }); }}>
+                <div className={"msg" + (isNewMsg ? " msg-enter" : "")} id={"m-" + m.id} key={m.id} onContextMenu={(e) => { e.preventDefault(); setCtxMenu({ m, x: e.clientX, y: e.clientY }); }} style={isNewMsg ? { "--msg-delay": `${staggerIdx * 60}ms` } as CSSProperties : undefined}>
                   <div className="msg-toolbar">
                     <button title={t("chat.emojiActions")} onClick={(e) => { const r = e.currentTarget.getBoundingClientRect(); setCtxMenu({ m, x: r.left - 180, y: r.bottom + 4 }); }}><Smile size={15} /></button>
                     <button title={t("chat.openThread")} onClick={() => startThread(m)}><MessageCircle size={15} /></button>
@@ -563,7 +570,7 @@ function ChannelFiles({ channelId }: { channelId: string }) {
   const [files, setFiles] = useState<any[]>([]);
   useEffect(() => { (async () => { const d = await api("GET", `/api/channels/${channelId}/files`); setFiles(d?.files || []); })(); }, [channelId]);
   return (
-    <div className="scroll">
+    <div className="scroll ch-view-enter">
       {files.length === 0 ? <div className="empty">{t("chat.noFiles")}</div>
         : files.map((f) => (
           <div key={f.id} className="card file-row">

--- a/web/src/views/Landing.tsx
+++ b/web/src/views/Landing.tsx
@@ -2,7 +2,7 @@
 // Rendered inside StoreProvider: in dev the store auto dev-logs-in, so me/slug are ready;
 // "Enter workspace" routes to the app (/s/:slug/channel) when signed in, else to /login.
 // Copy is English (open-source / global audience) and only claims capabilities verified in README.
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   AtSign, Network, ListChecks, Clock, ScanEye, Moon, BookMarked, Inbox, Boxes,
@@ -57,6 +57,50 @@ const ENGINES = [
 // hidden when this is empty rather than showing an empty "coming soon" header.
 const PLANNED_RUNTIMES: { name: string; icon: string }[] = [];
 
+// Hero title typewriter. Full text always holds the box (rest is visibility:hidden) so there's
+// zero layout shift; the caret rides between typed/rest. reduced-motion → full text, no caret.
+const HERO_TITLE = "Where your team and its\nAI agents work as one.";
+
+function renderTyped(s: string) {
+  return s.split("\n").map((line, i, arr) => (
+    <span key={i}>{line}{i < arr.length - 1 ? <br /> : null}</span>
+  ));
+}
+
+function HeroTitle() {
+  const reduced =
+    typeof window !== "undefined" && !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+  const [n, setN] = useState(reduced ? HERO_TITLE.length : 0);
+  useEffect(() => {
+    if (reduced) return;
+    let i = 0;
+    let interval: ReturnType<typeof setInterval> | undefined;
+    const start = setTimeout(() => {
+      interval = setInterval(() => {
+        i += 1;
+        setN(i);
+        if (i >= HERO_TITLE.length && interval) clearInterval(interval);
+      }, 48);
+    }, 350);
+    return () => {
+      clearTimeout(start);
+      if (interval) clearInterval(interval);
+    };
+  }, [reduced]);
+  const typed = HERO_TITLE.slice(0, n);
+  const rest = HERO_TITLE.slice(n);
+  const done = n >= HERO_TITLE.length;
+  return (
+    <h1 className="lp-hero__title" aria-label={HERO_TITLE.replace("\n", " ")}>
+      <span aria-hidden="true">
+        <span>{renderTyped(typed)}</span>
+        <span className={"lp-caret" + (done ? " is-done" : "")} />
+        <span className="lp-type__rest">{renderTyped(rest)}</span>
+      </span>
+    </h1>
+  );
+}
+
 export function Landing() {
   const { me, slug } = useStore();
   const navigate = useNavigate();
@@ -105,7 +149,7 @@ export function Landing() {
         <div className="lp-container">
           <div className="lp-hero__intro">
             <span className="lp-eyebrow">The open-source Claude Tag alternative</span>
-            <h1 className="lp-hero__title">Where your team and its<br />AI agents work as <em>one</em>.</h1>
+            <HeroTitle />
             <p className="lp-hero__sub">An open, self-hostable workspace where people and AI agents collaborate as colleagues — in channels, threads, and DMs. Agents are persistent, keep their own memory, and run on machines you control.</p>
             <div className="lp-hero__actions">
               <button className="lp-btn lp-btn--primary" onClick={enterWorkspace}>Enter workspace <ArrowRight size={18} /></button>


### PR DESCRIPTION
Motion pass across app + landing, all driven by unified motion tokens in styles.css :root with reduced-motion fallbacks: message-enter (staggered), app micro-interactions (button press, caret rotate, view-switch crossfade, modal/drawer, unread divider, toast/hovercard normalized), landing hero orb drift, hero-title typewriter. Verified with Playwright ground-truth: typewriter chars grow + h1 height constant (no layout shift) + caret; channel switch fires view-enter without breakage and history does not replay msg-enter; both pages render clean; typecheck (root+web) passes. See docs/motion-charter.md.