### PR TITLE
feat(docs): GitHub Pages auto-deploy + docs.getopentag.com

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -41,4 +41,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,44 @@
+name: Deploy Docs to GitHub Pages
+
+# Build and deploy docs-site/ to GitHub Pages whenever docs or this workflow change.
+# Path-filtered: pushes that don't touch docs-site/ or this file skip this workflow entirely.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs-site/**'
+      - '.github/workflows/docs-deploy.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only one concurrent deployment; never cancel an in-progress deploy (prevents partial publishes).
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install, build, and upload site
+        uses: withastro/action@v6
+        with:
+          path: docs-site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -79,7 +79,7 @@ Lets any machine join a server without cloning the repo: `npx @fancyboi999/open-
 
 - `scripts/build-daemon-pkg.mjs` — esbuild bundles **two** self-contained ESM files into `packages/daemon/dist/`: `cli.mjs` (the `open-tag-daemon` bin = `src/daemon/index.ts`) and `agent-cli.mjs` (the agent CLI = `src/cli/index.ts`, which `openTagBin.ts` injects in bundled mode). ESM output (so `import.meta.url` works) + a `createRequire` banner (so bundled CJS deps `ws`/`commander` and node builtins resolve); ws's optional native accelerators stay external. Run via `npm run pkg:daemon:build`.
 - `packages/daemon/package.json` — the publishable `@fancyboi999/open-tag-daemon` (bin `open-tag-daemon`, `files: [dist, README.md]`, zero runtime deps — everything bundled). `dist/` is gitignored and rebuilt in CI before publish.
-- CI: `.github/workflows/ci.yml` builds the bundle on every PR; `.github/workflows/publish-daemon.yml` publishes to npm on GitHub Release (needs the `NPM_TOKEN` secret); `.github/workflows/docs-deploy.yml` builds and deploys `docs-site/` to GitHub Pages (https://docs.getopentag.com) on push to `main` when `docs-site/**` changes.
+- CI: `.github/workflows/ci.yml` builds the bundle on every PR; `.github/workflows/publish-daemon.yml` publishes to npm on GitHub Release (via OIDC Trusted Publishing — no long-lived token); `.github/workflows/docs-deploy.yml` builds and deploys `docs-site/` to GitHub Pages (https://docs.getopentag.com) on push to `main` when `docs-site/**` changes.
 
 ### Data / shared (`src/`)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -79,7 +79,7 @@ Lets any machine join a server without cloning the repo: `npx @fancyboi999/open-
 
 - `scripts/build-daemon-pkg.mjs` — esbuild bundles **two** self-contained ESM files into `packages/daemon/dist/`: `cli.mjs` (the `open-tag-daemon` bin = `src/daemon/index.ts`) and `agent-cli.mjs` (the agent CLI = `src/cli/index.ts`, which `openTagBin.ts` injects in bundled mode). ESM output (so `import.meta.url` works) + a `createRequire` banner (so bundled CJS deps `ws`/`commander` and node builtins resolve); ws's optional native accelerators stay external. Run via `npm run pkg:daemon:build`.
 - `packages/daemon/package.json` — the publishable `@fancyboi999/open-tag-daemon` (bin `open-tag-daemon`, `files: [dist, README.md]`, zero runtime deps — everything bundled). `dist/` is gitignored and rebuilt in CI before publish.
-- CI: `.github/workflows/ci.yml` builds the bundle on every PR; `.github/workflows/publish-daemon.yml` publishes to npm on GitHub Release (needs the `NPM_TOKEN` secret).
+- CI: `.github/workflows/ci.yml` builds the bundle on every PR; `.github/workflows/publish-daemon.yml` publishes to npm on GitHub Release (needs the `NPM_TOKEN` secret); `.github/workflows/docs-deploy.yml` builds and deploys `docs-site/` to GitHub Pages (https://docs.getopentag.com) on push to `main` when `docs-site/**` changes.
 
 ### Data / shared (`src/`)
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 
 <p align="center">
   <a href="#quick-start">Quick Start</a> ·
+  <a href="https://docs.getopentag.com">Docs</a> ·
   <a href="docs/self-host.md">Self-Host</a> ·
   <a href="FEATURES.md">Features</a> ·
   <a href="ARCHITECTURE.md">Architecture</a> ·

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -5,7 +5,7 @@ import sitemap from '@astrojs/sitemap';
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://open-tag.dev',
+	site: 'https://docs.getopentag.com',
 	integrations: [
 		sitemap(),
 		starlight({
@@ -32,7 +32,7 @@ export default defineConfig({
 					tag: 'meta',
 					attrs: {
 						property: 'og:image',
-						content: 'https://open-tag.dev/og.png',
+						content: 'https://docs.getopentag.com/og.png',
 					},
 				},
 				{
@@ -46,7 +46,7 @@ export default defineConfig({
 					tag: 'meta',
 					attrs: {
 						name: 'twitter:image',
-						content: 'https://open-tag.dev/og.png',
+						content: 'https://docs.getopentag.com/og.png',
 					},
 				},
 			],

--- a/docs-site/public/CNAME
+++ b/docs-site/public/CNAME
@@ -1,0 +1,1 @@
+docs.getopentag.com


### PR DESCRIPTION
## Goal contract

Deploy `docs-site/` (Astro Starlight) to GitHub Pages and bind to `docs.getopentag.com`. All code-side changes are in this PR; GitHub Pages enablement and DNS record are to be done manually by the operator.

## Changes

| File | What changed |
|---|---|
| `.github/workflows/docs-deploy.yml` | **NEW** — path-filtered deploy workflow |
| `docs-site/public/CNAME` | **NEW** — `docs.getopentag.com` for GitHub Pages custom domain |
| `docs-site/astro.config.mjs` | `site` + `og:image` + `twitter:image` → `https://docs.getopentag.com` (was `open-tag.dev`) |
| `README.md` | Added `Docs` link → `https://docs.getopentag.com` in nav row |
| `ARCHITECTURE.md` | Added `docs-deploy.yml` to the CI workflow list |

## Workflow design

- **Trigger:** `push` to `main` with `paths: ['docs-site/**', '.github/workflows/docs-deploy.yml']` + `workflow_dispatch`. Path-filtered — pushes that don't touch docs never trigger this.
- **Actions:** `withastro/action@v6` (latest; `path: docs-site` for subdirectory) + `actions/deploy-pages@v5` (latest per official Astro docs). Action versions verified via WebFetch against https://docs.astro.build/en/guides/deploy/github/ and withastro/action release page.
- **Permissions:** `contents: read`, `pages: write`, `id-token: write` (required for OIDC-backed Pages deploy).
- **Concurrency:** `group: pages, cancel-in-progress: false` (prevents partial publishes).
- **Two-job structure:** `build` (checkout + withastro/action uploads artifact) → `deploy` (deploy-pages reads artifact, has `environment: github-pages`).

## Build evidence

```
cd docs-site && npm ci && npm run build
# → 7 page(s) built in 6.17s ✓
```

**CNAME in dist:**
```
$ cat docs-site/dist/CNAME
docs.getopentag.com
```

**New domain in index.html canonical + OG + Twitter:**
```
$ grep -o 'docs.getopentag.com[^"]*' docs-site/dist/index.html | head -6
docs.getopentag.com/
docs.getopentag.com/
docs.getopentag.com/
docs.getopentag.com/og.png
docs.getopentag.com/og.png
```
(canonical, og:url, og:image, twitter:image — all four present ✓)

**Zero stale `open-tag.dev` in dist:**
```
$ grep -r 'open-tag\.dev' docs-site/dist/; echo "exit:$?"
exit:1   ← zero hits ✓
```

## Independent verifier report

A fresh subagent ran before this PR was opened. **Overall: PASS.** Verified:
- Workflow trigger, permissions, concurrency, action versions, two-job structure, `environment` block, YAML syntax — all correct.
- CNAME content and presence in `dist/` — correct.
- All three `open-tag.dev` → `docs.getopentag.com` swaps in `astro.config.mjs` — correct.
- README nav link added, no other links touched.
- ARCHITECTURE.md updated, surrounding text intact.
- Scope: exactly 5 files changed, no `src/`, no `ci.yml`, no `publish-daemon.yml`, no docs content.

**What the verifier could not verify (requires operator action):**
- GitHub Pages must be enabled: `repo Settings → Pages → Source: GitHub Actions` (not "Deploy from branch"). Without this the `deploy-pages` action will fail.
- DNS: add a CNAME record `docs.getopentag.com → <github-pages-cname-target>` in Aliyun DNS. GitHub Pages will then issue TLS automatically.
- Live end-to-end deploy (requires GitHub Actions to execute after merge).

## What is NOT in this PR (operator to-do after merge)

1. **Enable GitHub Pages** in repo Settings → Pages → Source → GitHub Actions.
2. **Add DNS CNAME** in Aliyun: `docs` → `fancyboi999.github.io` (the standard GitHub Pages CNAME target for a user/org page).
3. After first successful deploy, verify `https://docs.getopentag.com` serves the Starlight site with valid TLS.