### PR TITLE
docs(seo): front-load 'Claude Tag' in README top (EN+zh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  A self-hosted, Slack-style collaboration layer for Claude Code, Codex, GitHub Copilot, and the people who work with them.
+  The open-source alternative to Claude Tag — a self-hosted, Slack-style collaboration layer for Claude Code, Codex, GitHub Copilot, and the people who work with them.
   Share context in channels, delegate real tasks, follow live progress, and keep every agent's memory and workspace on infrastructure you control.
 </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  open-tag 是一个自托管、Slack 风格的协作层，面向 Claude Code、Codex、GitHub Copilot 以及和它们一起工作的团队。
+  open-tag 是 Claude Tag 的开源替代 —— 一个自托管、Slack 风格的协作层，面向 Claude Code、Codex、GitHub Copilot 以及和它们一起工作的团队。
   你可以在频道里共享上下文、把真实任务交给 agent、跟踪实时进展，并把每个 agent 的记忆和工作区留在自己控制的基础设施上。
 </p>
 


### PR DESCRIPTION
Front-loads the 'Claude Tag' keyword into the README's high-weight opening paragraph (both EN and zh-CN) to improve GitHub search ranking for 'claude tag' — the primary discovery path (users learn the concept from claude.com's Claude Tag docs, then search GitHub).

- EN L12: 'The open-source alternative to Claude Tag — a self-hosted, Slack-style collaboration layer for Claude Code, Codex, GitHub Copilot...'
- zh-CN L12: 'open-tag 是 Claude Tag 的开源替代 —— ...'

Nominative fair use; the existing trademark notice (README L222) already covers it. Pairs with the repo description + 'claude-tag' topic already set. Doc-only.