### PR TITLE
docs(positioning): Claude Tag news-jack hook + 4-way comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
   Share context in channels, delegate real tasks, follow live progress, and keep every agent's memory and workspace on infrastructure you control.
 </p>
 
+> 🔥 **Claude Tag launched June 23, 2026** — Anthropic's always-on AI teammate that lives in Slack, learns your company, and works autonomously. It's closed, paid, Claude-only, and cloud-hosted.
+>
+> **open-tag is the open-source alternative — a workspace you run yourself, not a bot inside someone else's.** Self-host it so your data never leaves your network, bring any runtime (Claude Code, Codex, Copilot…), and run a whole team of specialized agents collaborating in channels, threads, DMs, and shared tasks.
+
 <p align="center">
   <img src="docs/hero.png" alt="open-tag — the open-source workspace for human and AI agent teams" width="100%" />
 </p>
@@ -62,17 +66,20 @@ Mention an agent in a channel and it receives the surrounding conversation, clai
 - **Self-hosted by design.** The server, database, daemon, workspaces, and attachments stay on infrastructure you control.
 - **Built for async collaboration.** Event wakeups, idle sleep, task claiming, reminders, threads, and freshness checks reduce duplicate work.
 
-## open-tag vs Claude Tag
+## How open-tag compares
 
-| | Claude Tag | **open-tag** |
-|---|---|---|
-| Shared channels and context | ✅ Inside Slack | ✅ Native workspace |
-| Persistent agent memory | ✅ | ✅ Workspace + `MEMORY.md` |
-| Proactive / async work | ✅ | ✅ Event wake + idle sleep |
-| Agents per workspace | One Claude | **Multiple specialized agents** |
-| Runtime | Claude | **Claude Code, Codex, Copilot, OpenCode, Kimi, Pi, Cursor** |
-| Hosting | Anthropic cloud | **Self-hosted** |
-| Source | Closed | **Apache-2.0** |
+The hosted products run your team's conversations and your agents' work on *their* servers. open-tag is the open-source one you run yourself.
+
+| | Claude Tag | Slock / Raft | Loop | **open-tag** |
+|---|:---:|:---:|:---:|:---:|
+| Channel-first workspace (channels · threads · DMs · tasks) | ✅¹ | ✅ | ✅ | ✅ |
+| Agents as persistent teammates with memory | ✅ | ✅ | ✅ | ✅ |
+| Multiple agents / multi-runtime | Claude only | ✅ | ✅ | ✅ Claude Code, Codex, Copilot, … |
+| **Open source** | ❌ | ❌ | ❌ | ✅ Apache-2.0 |
+| **Self-hosted — runs on your machines** | ❌ | ❌ | ❌ | ✅ |
+| **Your data never leaves your network** | ❌ | ❌ | ❌ | ✅ |
+
+¹ inside Slack. *Comparison based on each product's public site/docs (June 2026); corrections welcome.*
 
 ## How it works
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,6 +13,10 @@
   你可以在频道里共享上下文、把真实任务交给 agent、跟踪实时进展，并把每个 agent 的记忆和工作区留在自己控制的基础设施上。
 </p>
 
+> 🔥 **Claude Tag 于 2026 年 6 月 23 日发布** —— Anthropic 常驻 Slack 的 AI 队友，学习你的公司、自主工作。但它闭源、收费、锁定 Claude、只能跑在云端。
+>
+> **open-tag 是它的开源替代 —— 一个你自己掌控的工作区，而不是别人地盘里的一个 bot。** 自托管，数据永不出网；自带任意 runtime（Claude Code、Codex、Copilot…）；运行一整队各司其职、互相协作的 agent，在频道、话题、私信和共享任务里完成交付。
+
 <p align="center">
   <img src="docs/hero.png" alt="open-tag — 人类和 AI agent 团队的开源工作区" width="100%" />
 </p>
@@ -61,17 +65,20 @@
 - **按自托管设计。** Server、数据库、daemon、工作区和附件都留在你控制的基础设施上。
 - **为异步协作而生。** 事件唤醒、空闲休眠、任务认领、提醒、thread 和 freshness checks 可以减少重复劳动。
 
-## open-tag vs Claude Tag
+## open-tag 横向对比
 
-| | Claude Tag | **open-tag** |
-|---|---|---|
-| 共享频道和上下文 | ✅ 在 Slack 内 | ✅ 原生工作区 |
-| 持久 agent 记忆 | ✅ | ✅ 工作区 + `MEMORY.md` |
-| 主动 / 异步工作 | ✅ | ✅ 事件唤醒 + 空闲休眠 |
-| 每个工作区的 agents | 一个 Claude | **多个专门化 agents** |
-| Runtime | Claude | **Claude Code、Codex、Copilot、OpenCode、Kimi、Pi、Cursor** |
-| 托管方式 | Anthropic cloud | **自托管** |
-| 源码 | 闭源 | **Apache-2.0** |
+托管产品把你团队的对话和 agent 的工作跑在**它们的**服务器上。open-tag 是你自己跑的那个开源选项。
+
+| | Claude Tag | Slock / Raft | Loop | **open-tag** |
+|---|:---:|:---:|:---:|:---:|
+| Channel-first 工作区（频道 · 话题 · 私信 · 任务） | ✅¹ | ✅ | ✅ | ✅ |
+| Agent 作为有记忆的持久队友 | ✅ | ✅ | ✅ | ✅ |
+| 多 agent / 多 runtime | 仅 Claude | ✅ | ✅ | ✅ Claude Code、Codex、Copilot… |
+| **开源** | ❌ | ❌ | ❌ | ✅ Apache-2.0 |
+| **自托管 —— 跑在你自己的机器上** | ❌ | ❌ | ❌ | ✅ |
+| **数据永不出网** | ❌ | ❌ | ❌ | ✅ |
+
+¹ 在 Slack 内。*对比基于各产品官网/文档（2026 年 6 月），欢迎纠正。*
 
 ## 工作原理
 


### PR DESCRIPTION
Strengthens README positioning per competitive research:

- **News-jack hook** (top, EN+zh): leverages the June 23 2026 Claude Tag launch — 'closed, paid, Claude-only, cloud-hosted' vs open-tag 'a workspace you run yourself, not a bot inside someone else's.' Front-loads the 'open-source Claude Tag alternative' keyword + the self-host/data-control/multi-runtime/multi-agent differentiators.
- **4-way comparison**: replaces the Claude-Tag-only table with Claude Tag / Slock·Raft / Loop / open-tag. Top 3 rows all-✅ (same shape); bottom 3 (open source · self-hosted · data never leaves your network) ✅ only for open-tag.
- Hedged with 'based on each product's public site/docs (June 2026); corrections welcome.'

Doc-only. Pairs with the repo description + README-top 'Claude Tag' keyword + claude-tag topic already set.