### PR TITLE
fix(web): keep Select dropdown open when scrolling inside its long list

### DIFF
--- a/web/src/Select.tsx
+++ b/web/src/Select.tsx
@@ -26,11 +26,16 @@ export function Select({ value, options, onChange, placeholder, ariaLabel }: { v
     if (!open) return;
     setHi(Math.max(0, options.findIndex((o) => o.value === value)));
     const onDown = (e: MouseEvent) => { const t = e.target as Node; if (!btnRef.current?.contains(t) && !menuRef.current?.contains(t)) setOpen(false); };
-    const onScroll = () => setOpen(false);
+    const close = () => setOpen(false);
+    // Close on scroll EXCEPT when the scroll happens inside the menu itself. The menu is a fixed,
+    // viewport-positioned overlay, so an outer/page scroll drifts it off its trigger → close it. But a
+    // long option list scrolling within its own max-height must NOT dismiss the menu (capture-phase
+    // listener sees that inner scroll too, so we have to exclude it explicitly).
+    const onScroll = (e: Event) => { if (menuRef.current?.contains(e.target as Node)) return; setOpen(false); };
     document.addEventListener("mousedown", onDown);
-    window.addEventListener("resize", onScroll);
+    window.addEventListener("resize", close);
     window.addEventListener("scroll", onScroll, true);
-    return () => { document.removeEventListener("mousedown", onDown); window.removeEventListener("resize", onScroll); window.removeEventListener("scroll", onScroll, true); };
+    return () => { document.removeEventListener("mousedown", onDown); window.removeEventListener("resize", close); window.removeEventListener("scroll", onScroll, true); };
   }, [open, options, value]);
 
   const pick = (v: string) => { onChange(v); setOpen(false); btnRef.current?.focus(); };


### PR DESCRIPTION
## What

The custom `<Select>` dropdown closed itself the instant you scrolled **inside its own option list** — a long list (e.g. the 44-model gateway list) couldn't be browsed at all; the first wheel tick dismissed the menu instead of scrolling it.

## Root cause

`web/src/Select.tsx` registered a **capture-phase `window` `scroll` listener** that called `setOpen(false)` **unconditionally**. The intent is correct — the menu is a `fixed`, viewport-positioned overlay, so an **outer/page** scroll drifts it off its trigger and should dismiss it. But a capture-phase listener also fires for the menu's **own inner scroll** (`.sel-menu` is `max-height:280px; overflow-y:auto`), so scrolling a long list inside the menu was read as "page scrolled" → instant close.

Pre-existing since the component's first version; only surfaced now because **#110** fixed the menu's positioning, so long lists finally became usable (and scrollable) at all.

## Fix (one line + comment)

```js
const onScroll = (e: Event) => { if (menuRef.current?.contains(e.target as Node)) return; setOpen(false); };
```
Inner scroll (target inside the menu) → ignored. Outer/page scroll → still closes it (anti-drift behavior preserved). `resize` keeps a plain close handler.

## Verified (real browser — built `dist` + dev-login stack)

- Open the **Model** dropdown → scroll event targeted **inside** the menu → **menu stays open** ✓
- scroll event targeted **outside** the menu → **menu closes** ✓ (anti-drift preserved)
- `npm run typecheck` clean.

**Fail-loud note:** verified via precise `scroll`-event dispatch (target inside vs. outside `.sel-menu`) rather than a physical wheel on a 44-item list — the local verify stack had no daemon connected, so the Model list fell back to 3 static models (`menuScrollable:false`). A real wheel scroll on a long list emits the **same** `scroll` event with the **same** `.sel-menu` target, so the `onScroll` branch logic is exercised identically regardless of list length.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
