### PR TITLE
fix(showcase): restore the task → thread-pill → thread-panel form (don't flatten)

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -231,6 +231,13 @@ main.content-col{display:flex;flex-direction:column;height:100vh;background:var(
 .mention{color:var(--ink);font-weight:600;background:var(--mention);border-radius:4px;padding:0 3px}
 .composer{position:relative;padding:16px 28px 22px;border-top:1px solid var(--hair)}
 .showcase-readonly{display:flex;align-items:center;gap:8px;padding:14px 28px 18px;border-top:1px solid var(--hair);font-size:13px;color:var(--muted);font-style:italic}
+/* Showcase layout: the /showcase route never gets has-traj's 4th grid column, so this shell IS the single
+   1fr grid cell and lays out "channel column + thread panel" itself (no empty strip when the thread is closed). */
+.showcase-shell{display:flex;height:100vh;overflow:hidden;min-width:0}
+.showcase-shell>.content-col{flex:1;min-width:0}
+.showcase-thread{flex:none;width:var(--traj-w,360px)}  /* the thread panel; .thread-panel supplies the skin, mobile @820 makes it fullscreen */
+.showcase-case{transition:background .12s ease}
+.showcase-case.open{background:var(--surface-strong);box-shadow:inset 3px 0 0 var(--g-sky)}  /* highlight the case whose thread is open */
 .wake-hint{display:flex;align-items:center;gap:6px;font-size:12px;color:var(--muted);padding:0 2px 9px;line-height:1.4}
 .wake-hint svg{color:var(--g-sky);flex:0 0 auto}
 .wake-hint.wh-off svg{color:var(--muted-soft)}
@@ -777,6 +784,7 @@ aside.traj-col.profile-mode .scroll{flex:1;min-height:0;overflow:auto;margin:0 -
   .t-label{position:static;opacity:1;transform:none;background:none;color:var(--muted);font-size:10px;padding:0;box-shadow:none;pointer-events:auto;line-height:1.1}
   .rail a.t.active .t-label{color:var(--ink)}
   main.content-col{grid-row:1;min-width:0;height:auto;min-height:0}  /* overrides desktop height:100vh, delegated to grid 1fr; otherwise fills viewport and pushes bottom bar off screen */
+  .showcase-shell{grid-row:1;height:auto;min-height:0}  /* same delegation: the showcase wrapper is the grid cell here (its inner .content-col gets height:auto via the rule above; the thread panel goes fullscreen via .thread-panel) */
   /* sidebar (channels/members etc.) → left drawer, collapsed by default, hamburger toggles body.sb-open */
   .sidebar{position:fixed;top:0;bottom:0;left:0;width:84vw;max-width:330px;z-index:60;transform:translateX(-100%);transition:transform var(--dur-slow) var(--ease-quint);box-shadow:4px 0 28px var(--scrim)}
   body.sb-open .sidebar{transform:translateX(0)}

--- a/web/src/views/Showcase.tsx
+++ b/web/src/views/Showcase.tsx
@@ -1,17 +1,25 @@
 // Static, read-only Showcase page — four real-looking collaboration sessions rendered entirely
 // client-side from web/src/showcaseData.ts. Zero API, zero live agents, zero DB channel: the demo
-// is built into the frontend so every visitor sees it identically. Reuses the Chat message-bubble
-// styles (.msg / .msg-col / .mbody / .msg-atts / .task-pill / Avatar / MessageContent) so it still
-// reads like a genuine conversation — but agent avatars/names are intentionally NON-clickable and
-// trigger no profile/API (the old DB-channel showcase leaked host-machine skills on avatar click).
+// is built into the frontend so every visitor sees it identically.
+//
+// Form mirrors the real product (Chat.tsx): the channel shows one human "task" anchor per case with a
+// task badge + attachment + a "💬 N replies" thread-pill; clicking the pill opens the case's thread in a
+// right-side panel (the agents' collaboration = how that task got done). Nothing is flattened.
+//
+// Reuses the Chat message/thread styles (.msg / .msg-col / .mbody / .msg-meta / .task-pill / .thread-pill /
+// .thread-panel / .thread-head / .thread-sep / Avatar / MessageContent). Agent avatars/names are
+// intentionally NON-clickable and trigger no profile/API: the old DB-channel showcase leaked host-machine
+// skills on avatar click, so this static page never makes an avatar interactive. Thread open/close is pure
+// useState over static data — never openThread/startThread (those hit the server).
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Eye, CheckCircle2 } from "lucide-react";
+import { Eye, CheckCircle2, MessageCircle, X } from "lucide-react";
 import { Avatar } from "../Avatar.tsx";
 import { MessageContent } from "../messageRender.tsx";
 import { ChatSidebar } from "./ChatSidebar.tsx";
 import { IconFile, IconDownload } from "../icons.tsx";
 import { ST_LABEL } from "../TaskBoard.tsx";
-import { AGENTS, CASES, type ShowcaseAttachment, type ShowcaseLine, type ShowcaseTask } from "../showcaseData.ts";
+import { AGENTS, CASES, type ShowcaseAttachment, type ShowcaseCase, type ShowcaseLine, type ShowcaseTask } from "../showcaseData.ts";
 
 // Internal token links (@mention / #channel / task #N) are inert on this static page: with empty
 // mentions/channels the markdown renderer leaves them as plain text, and nav() is a no-op.
@@ -43,9 +51,16 @@ function ShowcaseAtt({ att }: { att: ShowcaseAttachment }) {
   );
 }
 
-// One message row — anchor (you) or a thread line (agent | you). Mirrors the Chat .msg layout but with
-// a non-clickable avatar/name and no live status/toolbar.
-function ShowcaseMsg({ line, task, attachment }: { line: ShowcaseLine; task?: ShowcaseTask | null; attachment?: ShowcaseAttachment }) {
+// One message row — anchor (you) or a thread line (agent | you). Mirrors the Chat .msg layout but with a
+// non-clickable avatar/name and no live status/toolbar. The meta row (task badge + thread-pill) only renders
+// on the channel anchor (where task / onOpenThread are passed), matching Chat's .msg-meta.
+function ShowcaseMsg({ line, task, attachment, replyCount, onOpenThread }: {
+  line: ShowcaseLine;
+  task?: ShowcaseTask | null;
+  attachment?: ShowcaseAttachment;
+  replyCount?: number;
+  onOpenThread?: () => void;
+}) {
   const { t } = useTranslation();
   const isYou = line.agent === null;
   const senderName = isYou ? "you" : line.agent!;
@@ -60,11 +75,18 @@ function ShowcaseMsg({ line, task, attachment }: { line: ShowcaseLine; task?: Sh
         </div>
         {!!line.content && <div className="mbody"><MessageContent content={line.content} mentions={[]} channels={[]} nav={noNav} /></div>}
         {attachment && <ShowcaseAtt att={attachment} />}
-        {task && (
+        {(task || onOpenThread) && (
           <div className="msg-meta">
-            <span className="task-pill st-done" style={{ cursor: "default" }}>
-              <CheckCircle2 size={11} /> #{task.number} {t(ST_LABEL[task.status] ?? task.status)}
-            </span>
+            {task && (
+              <span className="task-pill st-done" style={{ cursor: "default" }}>
+                <CheckCircle2 size={11} /> #{task.number} {t(ST_LABEL[task.status] ?? task.status)}
+              </span>
+            )}
+            {onOpenThread && (
+              <button className="thread-pill" onClick={onOpenThread}>
+                <MessageCircle size={12} /> {t("chat.replyCount", { count: replyCount ?? 0 })}
+              </button>
+            )}
           </div>
         )}
       </div>
@@ -72,28 +94,65 @@ function ShowcaseMsg({ line, task, attachment }: { line: ShowcaseLine; task?: Sh
   );
 }
 
+// Read-only thread panel — mirrors Chat's ThreadPanel structure (thread-head + thread-parent + thread-sep +
+// replies) but with NO composer (a static page can't reply): the footer is the read-only notice instead.
+function ShowcaseThread({ c, onClose }: { c: ShowcaseCase; onClose: () => void }) {
+  const { t } = useTranslation();
+  return (
+    <aside className="thread-panel showcase-thread">
+      <div className="thread-head">
+        <span className="grow">{t("chat.thread")}</span>
+        <button className="tp-close" onClick={onClose} title={t("chat.close")}><X size={15} /></button>
+      </div>
+      <div className="scroll">
+        <div className="thread-parent">
+          <ShowcaseMsg line={{ agent: null, content: c.anchor }} attachment={c.attachment} />
+        </div>
+        <div className="thread-sep">{t("chat.replyCount", { count: c.lines.length })}</div>
+        {c.lines.map((line, j) => <ShowcaseMsg key={j} line={line} />)}
+      </div>
+      <div className="showcase-readonly"><Eye size={14} />{t("chat.showcaseReadOnly")}</div>
+    </aside>
+  );
+}
+
 export function Showcase() {
   const { t } = useTranslation();
+  // Index of the case whose thread panel is open (null = closed). Pure local state over static data — no API.
+  const [openIdx, setOpenIdx] = useState<number | null>(null);
+  const openCase = openIdx != null ? CASES[openIdx] : null;
   return (
     <>
       <ChatSidebar />
-      <main className="content-col">
-        <div className="head chat-head">
-          <h1><Eye size={16} style={{ verticalAlign: "-3px", opacity: 0.7 }} /> {t("showcase.title")}</h1>
-          <small>{t("showcase.subtitle")}</small>
-        </div>
-        <div className="scroll ch-view-enter">
-          {CASES.map((c, i) => (
-            // A case = its human anchor message (carrying the task badge + attachment) followed by the
-            // thread replies inline. Cases after the first get a hairline top border as a visual divider.
-            <section key={i} className="showcase-case" style={i > 0 ? { marginTop: 18, paddingTop: 18, borderTop: "1px solid var(--hair)" } : undefined}>
-              <ShowcaseMsg line={{ agent: null, content: c.anchor }} task={c.task} attachment={c.attachment} />
-              {c.lines.map((line, j) => <ShowcaseMsg key={j} line={line} />)}
-            </section>
-          ))}
-        </div>
-        <div className="showcase-readonly"><Eye size={14} />{t("chat.showcaseReadOnly")}</div>
-      </main>
+      {/* Flex row: the channel column + (when a pill is clicked) the thread panel. The showcase route is not
+          a /channel path, so the app shell never gets has-traj's 4th grid column — this wrapper IS the single
+          grid cell and lays its own "main + thread" columns out, so a closed thread leaves no empty strip. */}
+      <div className="showcase-shell">
+        <main className="content-col">
+          <div className="head chat-head">
+            <h1><Eye size={16} style={{ verticalAlign: "-3px", opacity: 0.7 }} /> {t("showcase.title")}</h1>
+            <small>{t("showcase.subtitle")}</small>
+          </div>
+          <div className="scroll ch-view-enter">
+            {CASES.map((c, i) => (
+              // A case = its human "task" anchor (carrying the task badge, attachment, and the thread-pill).
+              // The collaboration transcript lives behind the pill — not flattened here. Cases after the first
+              // get a hairline top divider.
+              <section key={i} className={"showcase-case" + (openIdx === i ? " open" : "")} style={i > 0 ? { marginTop: 4, paddingTop: 18, borderTop: "1px solid var(--hair)" } : undefined}>
+                <ShowcaseMsg
+                  line={{ agent: null, content: c.anchor }}
+                  task={c.task}
+                  attachment={c.attachment}
+                  replyCount={c.lines.length}
+                  onOpenThread={() => setOpenIdx(i)}
+                />
+              </section>
+            ))}
+          </div>
+          <div className="showcase-readonly"><Eye size={14} />{t("chat.showcaseReadOnly")}</div>
+        </main>
+        {openCase && <ShowcaseThread c={openCase} onClose={() => setOpenIdx(null)} />}
+      </div>
     </>
   );
 }


### PR DESCRIPTION
Follow-up to #121. The static showcase page flattened every case's thread inline — that dropped open-tag's core form: a channel holds **task cards**, each with a `💬 N replies` thread-pill, and you click in to read the agents' collaboration in a **thread panel**. That collaboration *is* the task getting done; flattening it turned the demo into a wall of text.

`Showcase.tsx` now mirrors the real Chat form:
- Main column = the 4 case anchors as task cards (anchor + `✓ #N Done` badge + thread-pill).
- Click a pill → that case's thread opens in a right-side panel (reuses Chat's `ThreadPanel` classes) with the agent replies.
- Pure local `useState` over `showcaseData` — **still zero API, zero prop agents, avatars non-clickable** (no skills-leak regression).

Only `web/src/views/Showcase.tsx` (rewrite) + `web/src/styles.css` (+8). No back-end / data change → no migration.

**Browser-verified:** pill opens the matching case's thread (replies 7/5/4/4), switching cases swaps the panel + main-column highlight, X closes it, `clickableAvatars=0` / `agentProfileLinks=0`. typecheck clean.