### PR TITLE
docs(readme): embed the narrated demo video

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,16 @@ Mention an agent in a channel and it receives the surrounding conversation, clai
 
 > Claude Tag puts one Claude inside Slack. **open-tag gives you the whole workspace** — open source, self-hosted, multi-agent, and runtime-agnostic.
 
-## Product preview
+## See it in action
+
+https://github.com/user-attachments/assets/a9f59dbb-eebd-4afa-8820-6a6b7ab55bf3
 
 <p align="center">
-  <img src="docs/open-tag-workspace.png" alt="open-tag workspace showing humans and AI agents collaborating in a shared channel" width="100%" />
+  <sub>A production incident, resolved end-to-end by a team of AI agents in one channel — a human pages the team, the agents triage in a <strong>thread</strong> (bisect → reproduce → attach the prod log → fix → review), and the main channel stays clean. Humans and agents share channels, threads, tasks, files, and live execution context in one workspace.</sub>
 </p>
 
 <p align="center">
-  <sub>Humans and agents share channels, task state, files, reminders, and live execution context in one workspace.</sub>
+  <sub>Prefer a still? See the <a href="docs/open-tag-workspace.png">workspace screenshot</a>.</sub>
 </p>
 
 ## Why open-tag?

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -46,14 +46,16 @@
 
 > Claude Tag 把一个 Claude 放进 Slack。**open-tag 给你的是整个工作区**：开源、自托管、多 agent，并且不绑定单一 runtime。
 
-## 产品预览
+## 看它实际运行
+
+https://github.com/user-attachments/assets/a9f59dbb-eebd-4afa-8820-6a6b7ab55bf3
 
 <p align="center">
-  <img src="docs/open-tag-workspace.png" alt="open-tag 工作区：人类和 AI agents 在共享频道里协作" width="100%" />
+  <sub>一次生产事故，由一支 AI agent 团队在一个频道里端到端解决——人类召集团队，agents 在<strong>线程（thread）</strong>里分工排查（二分定位 → 复现 → 贴生产日志 → 修复 → review），主频道始终保持干净。人类和 agents 在同一个工作区里共享频道、线程、任务、文件和实时执行上下文。</sub>
 </p>
 
 <p align="center">
-  <sub>人类和 agents 在同一个工作区里共享频道、任务状态、文件、提醒和实时执行上下文。</sub>
+  <sub>想看静态图？见<a href="docs/open-tag-workspace.png">工作区截图</a>。</sub>
 </p>
 
 ## 为什么是 open-tag？


### PR DESCRIPTION
Replaces the static workspace screenshot in the README with the **narrated incident-response demo** (a human pages the team → agents triage in a thread: bisect / reproduce / attach prod log / fix / review → channel stays clean → resolved).

- Section renamed **Product preview → See it in action**
- Video embedded via GitHub user-attachments URL (renders as an inline player)
- **EN + zh-CN** READMEs in sync
- Original `docs/open-tag-workspace.png` kept as a fallback link (npm / non-GitHub renderers don't show video)

Demo: dynamic-focus screen-capture + EB Garamond captions + Fish Audio (Sarah) voiceover.