### PR TITLE
Fix previous channel's messages flashing during channel-switch skeleton load

### DIFF
--- a/web/src/views/Chat.tsx
+++ b/web/src/views/Chat.tsx
@@ -186,8 +186,21 @@ export function Chat() {
   // (the live bar deep-links to Activity via ?agentTab=activity; without this it would stick across opens).
   const closeProfile = () => { setProfile(null); setSp((prev) => { const n = new URLSearchParams(prev); n.delete("agentTab"); return n; }, { replace: true }); };
 
+  // Channel-scoped state (loaded messages + load gate + has-more) belongs to one channel. When the
+  // channel changes, reset it *synchronously during render* (React's "adjust state when a prop changes"
+  // pattern) rather than in the effect below — effects run after paint, so resetting there leaves one
+  // painted frame (and the whole skeleton phase) showing the previous channel's messages. Resetting here
+  // makes the new channel paint its skeleton immediately, never the prior channel's stale list.
+  const [shownChannelId, setShownChannelId] = useState(cur?.id);
+  if (cur?.id !== shownChannelId) {
+    setShownChannelId(cur?.id);
+    setMsgs([]);
+    setLoaded(false);
+    setHasMore(false);
+  }
+
   useEffect(() => { if (!channelId && cur) nav(`/s/${slug}/channel/${cur.id}`, { replace: true }); }, [channelId, cur, slug, nav]);
-  useEffect(() => { if (!cur) return; setThread(null); setProfile(null); setLoaded(false); loadingOlderRef.current = false; prependRestoreRef.current = null; subscribeChannel(cur.id); (async () => { // switching channels closes any open thread + profile overlay from the previous channel (the live trace itself persists — accumulated in the store, see store.tsx); join the room while viewing so message:new arrives live (covers public non-member channels + channels relevant after connect)
+  useEffect(() => { if (!cur) return; setThread(null); setProfile(null); loadingOlderRef.current = false; prependRestoreRef.current = null; subscribeChannel(cur.id); (async () => { // switching channels closes any open thread + profile overlay from the previous channel (loaded/msgs/hasMore reset happens synchronously in the render-phase guard above) (the live trace itself persists — accumulated in the store, see store.tsx); join the room while viewing so message:new arrives live (covers public non-member channels + channels relevant after connect)
     const d = await api("GET", `/api/messages/channel/${cur.id}?limit=${PAGE_SIZE}`); const ms: Msg[] = d.messages || []; setMsgs(ms); setLoaded(true); setHasMore(!!d.hasMore); markRead(cur.id);
     const ids = ms.map((m) => m.id);
     if (ids.length) { try { setThreadMeta(await api("GET", `/api/channels/${cur.id}/threads?parentMessageIds=${ids.join(",")}`) || {}); } catch { setThreadMeta({}); } } else setThreadMeta({});


### PR DESCRIPTION
## Problem

Switching channels briefly rendered the **previous** channel's messages on top of
the new channel's skeleton loader. Repro: open channel A (loaded), switch to B —
during B's fetch window the skeleton shows *and* A's old message list shows under
B's header.

## Root cause (`web/src/views/Chat.tsx`)

- On channel switch (`cur.id` changes) `msgs` was never reset, and `loaded` was reset
  only inside a `useEffect` — which runs **after paint**.
- The message list render (lines ~300–303) is `{!loaded && <Skeleton/>}{loaded && !msgs.length && <Empty/>}{msgs.map(...)}` — `msgs.map` is **not** gated by `loaded`.
- So on switch: one painted frame shows A's full list (cur=B, msgs=A, loaded still true),
  then the effect sets `loaded=false` → skeleton appears **but msgs is still A** → skeleton
  and A's stale messages render together.

## Fix

Reset the channel-scoped state (`msgs` / `loaded` / `hasMore`) **synchronously during
render** using React's "adjust state when a prop changes" pattern, instead of in the
post-paint effect. The new channel paints only its skeleton and never the prior
channel's stale list. The now-redundant `setLoaded(false)` is dropped from the switch
effect (single reset path, no dual-reset hybrid).

Surgical: one file, ~13 lines.

## Verification

- `web` typecheck: `src/` clean (only pre-existing `vite.config.ts` `process` noise, unrelated).
- `npm run build --prefix web`: passes (vite build + prerender).
- Faithful React repro of the exact 300–303 render gating, DOM read mid-load:
  - **before**: `msgCount=3` (channel A's) + skeleton
  - **after**: `msgCount=0` + skeleton only
  - after load: both render the new channel correctly.

Not run: full live stack (backend + DB + redis + dev-login E2E) — change is pure
render-timing; the repro reproduces the exact gating. No schema/route/feature-surface
change, so no doc-sync update needed.
