### PR TITLE
fix(tasks): keep drag overlay anchored to pointer

### DIFF
--- a/test/tasksBoardMoveUx.unit.test.ts
+++ b/test/tasksBoardMoveUx.unit.test.ts
@@ -7,11 +7,15 @@
 //  2. the drop indicator is a `.drop-slot` appended AFTER the cards (never the old `.drop-hint` banner that
 //     overlapped the dragged card);
 //  3. cards animate between columns via a `.tk-slot` transition, with a prefers-reduced-motion off-switch.
+//  4. the DragOverlay child does NOT set `transform`; dnd-kit writes the pointer-following translate transform
+//     on its positioned overlay wrapper, and keeping the child transform-free preserves that contract while the
+//     visual scale lives on the inner card.
 import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 
 const css = fs.readFileSync(new URL("../web/src/styles.css", import.meta.url), "utf8");
+const src = fs.readFileSync(new URL("../web/src/TaskBoard.tsx", import.meta.url), "utf8");
 
 function ruleBody(selector: string): string {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -45,4 +49,30 @@ test("drop indicator is an appended slot, not the old overlapping banner", () =>
 test("cards animate between columns, with a reduced-motion off-switch", () => {
   assert.match(ruleBody(".tk-slot"), /transition\s*:\s*transform/, "the FLIP slot must transition transform");
   assert.match(css, /prefers-reduced-motion:\s*reduce\)\s*\{\s*\.tk-slot\s*\{\s*transition:\s*none/, "reduced-motion must disable the slot transition");
+});
+
+test("drag overlay preserves dnd-kit's pointer-following transform", () => {
+  assert.doesNotMatch(
+    ruleBody(".card-overlay"),
+    /(?:^|;)\s*transform\s*:/,
+    "the DragOverlay child must not declare transform; dnd-kit owns that property for pointer alignment",
+  );
+  assert.doesNotMatch(
+    css,
+    /prefers-reduced-motion:\s*reduce\)\s*\{\s*\.card-overlay\s*\{[^}]*transform\s*:/,
+    "reduced-motion must not add a transform override back onto the DragOverlay child",
+  );
+});
+
+test("drag overlay is portaled to body so fixed positioning is viewport-based", () => {
+  // `.board-scroll` runs an enter animation with fill-mode `both`; after it completes, browsers keep an
+  // identity matrix transform on that ancestor. A dnd-kit DragOverlay rendered under that subtree uses
+  // position:fixed, but fixed descendants of a transformed ancestor are positioned against that ancestor,
+  // not the viewport. The overlay therefore must escape to <body>.
+  const portaledOverlay = /createPortal\(\s*[\s\S]*?<DragOverlay[\s\S]*?className="card-overlay"[\s\S]*?<\/DragOverlay>[\s\S]*?,\s*document\.body\s*,?\s*\)/;
+  assert.match(
+    src,
+    portaledOverlay,
+    "the task DragOverlay must render through createPortal(..., document.body), outside .board-scroll's transform-containing subtree",
+  );
 });

--- a/web/src/TaskBoard.tsx
+++ b/web/src/TaskBoard.tsx
@@ -256,14 +256,17 @@ export function TaskBoard({ channelId, onOpenThread }: { channelId: string | nul
       </div>
       {filtered.length === 0 ? <PaneEmpty icon={<ListChecks size={30} />} title={tasks.length ? t("tasks.emptyFiltered") : channelId ? t("tasks.emptyChannel") : t("tasks.emptyServer")} />
         : view === "board" ? (
-          // DragOverlay renders the moving card in a top-level portal (never clipped / never painted behind a column)
           <DndContext sensors={sensors} onDragStart={(e) => setActiveId(String(e.active.id))} onDragCancel={() => setActiveId(null)} onDragEnd={onDragEnd}>
             <div ref={boardRef} className={"task-board " + boardLayout + (activeId ? " dragging" : "")}>
               {TCOLS.map(([k, labelKey]) => <DroppableCol key={k} k={k} labelKey={labelKey} />)}
             </div>
-            <DragOverlay dropAnimation={null}>
-              {activeTask ? <div className="card-overlay"><Card t={activeTask} /></div> : null}
-            </DragOverlay>
+            {/* Body-portal the overlay so dnd-kit's fixed-position wrapper is not re-based by .board-scroll's enter-animation transform. */}
+            {createPortal(
+              <DragOverlay dropAnimation={null}>
+                {activeTask ? <div className="card-overlay"><Card t={activeTask} /></div> : null}
+              </DragOverlay>,
+              document.body,
+            )}
           </DndContext>
         ) : (
           <div className="task-list">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -353,9 +353,9 @@ main.content-col{display:flex;flex-direction:column;height:100vh;background:var(
 .tk-slot{transition:transform .22s cubic-bezier(.22,1,.36,1),opacity .22s ease}
 @media (prefers-reduced-motion:reduce){.tk-slot{transition:none}}
 /* DragOverlay: the moving copy of the card lifts off the board — soft shadow + slight scale, never clipped (it's portaled to <body>). */
-.card-overlay{cursor:grabbing;transform:scale(1.03);box-shadow:0 16px 36px rgba(12,10,9,.20)}
-.card-overlay .card.task{margin-bottom:0;border-color:var(--hair-strong)}
-@media (prefers-reduced-motion:reduce){.card-overlay{transform:none}}
+.card-overlay{cursor:grabbing;box-shadow:0 16px 36px rgba(12,10,9,.20)}
+.card-overlay .card.task{margin-bottom:0;border-color:var(--hair-strong);transform:scale(1.03)}
+@media (prefers-reduced-motion:reduce){.card-overlay .card.task{transform:none}}
 .actlog{display:flex;flex-direction:column;gap:2px}
 .act{display:flex;align-items:baseline;gap:10px;padding:5px 6px;border-radius:6px;font-size:14px;line-height:1.5}
 .act:hover{background:var(--surface-strong)}


### PR DESCRIPTION
## Goal Contract

End state: dragging a task card on the Tasks board keeps the preview anchored to the pointer at the same relative point inside the card. The preview must not drift right/down when the board lives under an animated/transformed container.

Constraints: frontend-only bugfix; no backend/schema/API behavior change; no docs update required because the user-facing task-board behavior is unchanged and already documented.

## Root Cause

`.board-scroll` runs `animation: view-enter ... both`, which leaves a computed identity transform (`matrix(1, 0, 0, 1, 0, 0)`) on the task-board scroll container after the animation. dnd-kit renders `DragOverlay` with a `position: fixed` wrapper; when that wrapper is still under a transformed ancestor, browser fixed-positioning is rebased to that ancestor instead of the viewport. That added the board container's left/top offset to the overlay, which is why the preview appeared to the pointer's right/down.

There was also a smaller transform-safety issue: `.card-overlay` had its own `transform: scale(1.03)`. The visual scale now lives on the inner `.card.task`, leaving the overlay child/root transform-free.

## Changes

- Body-portal the task `DragOverlay` to `document.body` while keeping it inside React's `DndContext` tree, so context is preserved but browser positioning escapes `.board-scroll`'s transform-containing block.
- Move the overlay visual scale from `.card-overlay` to `.card-overlay .card.task`.
- Extend `test/tasksBoardMoveUx.unit.test.ts` with regression contracts for:
  - `.card-overlay` not declaring `transform`
  - reduced-motion not reintroducing root overlay transform
  - task `DragOverlay` rendering through `createPortal(..., document.body)`

## Evidence

Red/green:
- Before fix, the new regression failed on `.card-overlay{transform:scale(1.03)}`.
- Before portal fix, the new portal regression failed because `DragOverlay` rendered inline under `.board-scroll`.
- After fix: `npx tsx --test --test-force-exit test/tasksBoardMoveUx.unit.test.ts` passed 5/5.

Commands run:
- `npm run typecheck` passed (`tsc --noEmit && tsc --noEmit -p web/tsconfig.json`).
- `npm --prefix web run build` passed (Vite built 2534 modules; prerender completed).
- `npx tsx --test --test-force-exit test/tasksBoardMoveUx.unit.test.ts test/tasksBoardLayout.unit.test.ts test/selectMenuPortal.unit.test.ts` passed 9/9.

Real browser verification (Playwright against local Vite + server):
- URL: `http://127.0.0.1:5301/s/open-tag/tasks?as=you`
- Server: `localhost:7802`, Vite: `127.0.0.1:5301`
- Created a real task through `/api/tasks/channel/:id`.
- Drag start card rect: `x=342 y=295 w=280 h=127`; pointer down at `x=384 y=329`, relative offset `42,34`.
- During drag after moving pointer to `x=624 y=387`:
  - overlay wrapper parent: `BODY`
  - overlay wrapper transform: `matrix(1, 0, 0, 1, 240, 58)`
  - pointer offset from overlay: `42,34`
  - `.card-overlay` transform: `none`
  - inner card transform: `matrix(1.03, 0, 0, 1.03, 0, 0)`

Independent verifier report:
- No blocking findings.
- Verified normal drag offset and reduced-motion drag offset in a real browser.
- Verified `.board-scroll` retained identity transform, overlay was body-portaled, and status menu portal remained unaffected.
- Ran `npm run typecheck`, `npm --prefix web run build`, and related tests successfully.

Independent code review:
- No confirmed bugs/regressions.
- Noted `createPortal(document.body)` is safe here because the component already uses a status-menu body portal, and the new overlay portal remains inside `DndContext` in React tree.
- Suggested clarifying one test comment; addressed before commit.

## Fail-Loud

Skipped:
- Full backend/integration suite; this is a narrow frontend drag-overlay bugfix with no API/schema changes.
- Mobile/touch dragging.
- Every board layout/status permutation.

Warnings:
- Local Vite HMR emitted the existing React Fast Refresh warning about `TaskBoard.tsx` exporting both component and `ST_LABEL`; production build passed.
- An early throwaway verification script produced one `/api/channels` request without `x-server-id`, causing a local 400/500 log; corrected script used the normal bootstrap flow and all relevant page/API requests succeeded.

Not verified:
- Cross-browser behavior outside Chromium/Playwright.
