### PR TITLE
Show who reacted in a hover tooltip on reaction chips

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -498,9 +498,13 @@ aside.traj-col h2{position:relative;font-size:12px;font-weight:600;letter-spacin
 .file-thumb{width:40px;height:40px;border-radius:8px;object-fit:cover;flex:none;background:var(--surface-strong)}
 /* Message emoji reactions */
 .msg-rx{display:flex;align-items:center;gap:5px;margin-top:5px;flex-wrap:wrap}
-.rx-chip{display:inline-flex;align-items:center;gap:4px;font-size:13px;line-height:1;padding:3px 8px;border:1px solid var(--hair-strong);border-radius:9999px;background:var(--surface);color:var(--body);cursor:pointer}
+.rx-chip{position:relative;display:inline-flex;align-items:center;gap:4px;font-size:13px;line-height:1;padding:3px 8px;border:1px solid var(--hair-strong);border-radius:9999px;background:var(--surface);color:var(--body);cursor:pointer}
 .rx-chip:hover{background:var(--surface-strong)}
 .rx-chip.on{background:var(--tint-blue);border-color:var(--g-sky);color:var(--ink);font-weight:600}
+/* "who reacted" hover tooltip on a reaction chip — replaces the native title (slow/unstyled/absent on touch). Reuses the popover skin (.agent-hovercard / .rx-pop tokens). */
+.rx-tip{position:absolute;bottom:100%;left:50%;transform:translateX(-50%) translateY(2px);margin-bottom:7px;width:max-content;max-width:220px;white-space:normal;font-size:12px;line-height:1.35;font-weight:400;color:var(--ink-2);background:var(--surface);border:1px solid var(--hair-strong);border-radius:8px;box-shadow:0 8px 24px var(--shadow-3);padding:6px 9px;opacity:0;pointer-events:none;transition:opacity var(--dur-fast) var(--ease-quint),transform var(--dur-fast) var(--ease-quint);z-index:60}
+.rx-chip:hover .rx-tip,.rx-chip:focus-visible .rx-tip{opacity:1;transform:translateX(-50%) translateY(0)}
+@media (prefers-reduced-motion:reduce){.rx-tip{transition:none}}
 .rx-add-wrap{position:relative;display:inline-flex}
 .rx-add{font-size:13px;line-height:1;padding:3px 7px;border:1px solid var(--hair);border-radius:9999px;background:var(--surface);color:var(--muted-soft);cursor:pointer;opacity:0;transition:opacity .12s}
 .msg:hover .rx-add,.rx-add:focus{opacity:1}

--- a/web/src/views/Chat.tsx
+++ b/web/src/views/Chat.tsx
@@ -85,7 +85,8 @@ function Reactions({ m, mine, onReact }: { m: Msg; mine: string; onReact: (emoji
     <div className="msg-rx">
       {rs.map((r) => {
         const did = !!mine && r.reactorIds?.includes(mine);
-        return <button key={r.emoji} className={"rx-chip" + (did ? " on" : "")} title={(r.reactorNames || []).join(", ")} onClick={() => onReact(r.emoji, !!did)}>{r.emoji} {r.count}</button>;
+        const names = (r.reactorNames || []).filter(Boolean).join(", "); // who reacted — shown in a custom hover tooltip (native title is slow/unstyled/missing on touch)
+        return <button key={r.emoji} className={"rx-chip" + (did ? " on" : "")} onClick={() => onReact(r.emoji, !!did)}>{r.emoji} {r.count}{names ? <span className="rx-tip" role="tooltip">{names}</span> : null}</button>;
       })}
       <span className="rx-add-wrap">
         <button className="rx-add" title={i18n.t("chat.addReaction")} onMouseDown={(e) => { e.preventDefault(); setPick((v) => !v); }}><Smile size={15} /></button>


### PR DESCRIPTION
## Problem

A message's reaction chip only exposed the reactor names via the native HTML
`title` attribute. That tooltip has a ~1s hover delay, no styling, and never
appears on touch devices — so users couldn't tell **who** reacted with an emoji.

## Fix (frontend only — backend already provides the data)

`reactorNames` is already on every reaction (initial load + realtime
`message:updated`), so no backend change is needed. Replace the native `title`
on `.rx-chip` (`web/src/views/Chat.tsx`) with a styled `.rx-tip` hover tooltip
that renders the names, reusing the existing popover skin (`.agent-hovercard` /
`.rx-pop` tokens). Surgical: 2 files, +7/-2.

- Tooltip opens on `:hover` **and** `:focus-visible` (keyboard reachable).
- Names stay in the accessible tree (the span text is real content, no `aria-label`
  override that would hide the emoji/count from screen readers).
- Long reactor lists wrap within `max-width:220px`.
- Honors `prefers-reduced-motion`.

## Verification

- `web` typecheck: `src/` clean. `npm run build --prefix web`: passes.
- Real browser (chrome-devtools), rendering the exact `.rx-chip`/`.rx-tip` markup
  against the real `styles.css`:
  - hover a chip → styled tooltip with reactor names appears above it (screenshot in task thread).
  - long-name case wraps correctly within max-width.
  - a11y snapshot: chip button reads `"👍 3 fancy, 小明, backenddev"` (names in the tree).

No schema/route/feature-surface change → no doc-sync update.
