### PR TITLE
fix(showcase): stop open-case hover from splitting the highlight and clipping the accent bar

### DIFF
--- a/test/showcaseOpenHoverHighlight.unit.test.ts
+++ b/test/showcaseOpenHoverHighlight.unit.test.ts
@@ -1,0 +1,38 @@
+// Unit regression for the Showcase open-case hover highlight.
+// Run: npx tsx --test --test-force-exit test/showcaseOpenHoverHighlight.unit.test.ts
+//
+// Bug: a Showcase case whose thread is open (.showcase-case.open) gets a surface-strong fill + an
+// inset accent bar. It reuses Chat's .msg, whose :hover paints an opaque, LIGHTER (canvas-soft)
+// rounded block — on the open case's darker fill that reads as a reversed, half-height highlight AND,
+// being opaque, clips the inset accent bar to a stray segment above the avatar ("hover makes half the
+// message vanish" + "blue bar under the avatar"). Fix: inside an open case, suppress the per-message
+// hover fill so the fill stays uniform and the accent bar runs full-height. Must stay SCOPED — the
+// global .msg:hover (real Chat channels) must be untouched.
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const css = fs.readFileSync(new URL("../web/src/styles.css", import.meta.url), "utf8");
+
+function ruleBody(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const m = new RegExp(`${escaped}\\s*\\{([^}]*)\\}`).exec(css);
+  assert.ok(m, `missing CSS rule for ${selector}`);
+  return m[1]!;
+}
+
+test("open Showcase case clears the per-message hover fill (no reversed half-height block; accent bar stays full-height)", () => {
+  const body = ruleBody(".showcase-case.open .msg:hover");
+  assert.match(body, /background\s*:\s*transparent\b/, `open-case hover must clear the .msg fill, got: ${body}`);
+});
+
+test("global .msg:hover (real Chat channels) is untouched — still the canvas-soft hover block", () => {
+  const body = ruleBody(".msg:hover");
+  assert.match(body, /background\s*:\s*var\(--canvas-soft\)/, `global .msg:hover must keep its hover block, got: ${body}`);
+});
+
+test("the open case still carries the fill + accent bar the hover fix relies on", () => {
+  const body = ruleBody(".showcase-case.open");
+  assert.match(body, /background\s*:\s*var\(--surface-strong\)/, `open case lost its fill: ${body}`);
+  assert.match(body, /box-shadow\s*:\s*inset\s+3px\s+0\s+0\s+var\(--g-sky\)/, `open case lost its accent bar: ${body}`);
+});

--- a/test/showcaseOpenHoverHighlight.unit.test.ts
+++ b/test/showcaseOpenHoverHighlight.unit.test.ts
@@ -36,3 +36,11 @@ test("the open case still carries the fill + accent bar the hover fix relies on"
   assert.match(body, /background\s*:\s*var\(--surface-strong\)/, `open case lost its fill: ${body}`);
   assert.match(body, /box-shadow\s*:\s*inset\s+3px\s+0\s+0\s+var\(--g-sky\)/, `open case lost its accent bar: ${body}`);
 });
+
+test("open case is a contained card — content indents off the accent bar (avatar not flush on the bar)", () => {
+  const body = ruleBody(".showcase-case.open .msg");
+  // drop the reused negative side-margins (Chat's .msg uses 0 -12px) so content sits inside the card…
+  assert.match(body, /margin\s*:\s*0\s+0\s+6px/, `open-case .msg must drop its negative side-margins: ${body}`);
+  // …and indent past the 3px inset accent bar so the avatar clears it instead of sitting flush.
+  assert.match(body, /padding-left\s*:\s*18px/, `open-case content must indent off the accent bar: ${body}`);
+});

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -243,6 +243,13 @@ main.content-col{display:flex;flex-direction:column;height:100vh;background:var(
 .showcase-thread{flex:none;width:var(--traj-w,360px)}  /* the thread panel; .thread-panel supplies the skin, mobile @820 makes it fullscreen */
 .showcase-case{transition:background .12s ease}
 .showcase-case.open{background:var(--surface-strong);box-shadow:inset 3px 0 0 var(--g-sky)}  /* highlight the case whose thread is open */
+/* The open case reuses Chat's .msg, whose :hover paints an opaque, *lighter* (canvas-soft) rounded block.
+   On the open case's darker (surface-strong) fill that block reads as a reversed, half-height highlight AND,
+   being opaque, clips the lower part of the inset accent bar — leaving a stray bar segment above the avatar.
+   Inside an open case the whole case already is the highlight, so suppress the per-message hover fill: the
+   fill stays uniform and the accent bar runs full-height. Scoped to .showcase-case.open — global .msg:hover
+   (real Chat channels) is untouched. */
+.showcase-case.open .msg:hover{background:transparent}
 .wake-hint{display:flex;align-items:center;gap:6px;font-size:12px;color:var(--muted);padding:0 2px 9px;line-height:1.4}
 .wake-hint svg{color:var(--g-sky);flex:0 0 auto}
 .wake-hint.wh-off svg{color:var(--muted-soft)}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -243,6 +243,10 @@ main.content-col{display:flex;flex-direction:column;height:100vh;background:var(
 .showcase-thread{flex:none;width:var(--traj-w,360px)}  /* the thread panel; .thread-panel supplies the skin, mobile @820 makes it fullscreen */
 .showcase-case{transition:background .12s ease}
 .showcase-case.open{background:var(--surface-strong);box-shadow:inset 3px 0 0 var(--g-sky)}  /* highlight the case whose thread is open */
+/* Open case = a contained card: drop .msg's reused negative side-margins and indent the content so the
+   avatar/text clear the inset accent bar instead of sitting flush on it — the bar otherwise pressed right
+   against the avatar's left edge. (Keep the 6px bottom margin so the content doesn't hug the card floor.) */
+.showcase-case.open .msg{margin:0 0 6px;padding-left:18px}
 /* The open case reuses Chat's .msg, whose :hover paints an opaque, *lighter* (canvas-soft) rounded block.
    On the open case's darker (surface-strong) fill that block reads as a reversed, half-height highlight AND,
    being opaque, clips the lower part of the inset accent bar — leaving a stray bar segment above the avatar.


### PR DESCRIPTION
## What

On the Showcase route page (`/s/:server/showcase`), hovering a message inside a case whose
thread is open looked broken in two ways:

1. **"Hover makes half the message vanish."** The hover highlight split into a dark band on top
   and a *lighter* rounded block below — a reversed, half-height highlight.
2. **"Blue bar under the avatar."** A stray segment of the blue accent bar floated above the
   avatar instead of running the full height of the case.

Both are the **same root cause**.

## Root cause

A case whose thread is open gets `.showcase-case.open`:

```css
.showcase-case.open{ background:var(--surface-strong); box-shadow:inset 3px 0 0 var(--g-sky) }
```

i.e. a darker `surface-strong` (#f0efed) fill + a left-edge `g-sky` inset accent bar. But the case
reuses Chat's `.msg`, and `.msg:hover{ background:var(--canvas-soft) }` (#fafafa) is **lighter than
the open fill**. So hovering a message in an open case painted an opaque, lighter block on the darker
fill:

- it read as a **reversed, half-height** highlight (only covers `.msg`, not the case's 18px
  `padding-top`) → "half the message vanished";
- being opaque, it **clipped the lower part of the inset accent bar**, leaving only the segment in
  the `padding-top` band visible → "blue bar above/under the avatar".

## Fix

One scoped rule — inside an open case the whole case already *is* the highlight, so suppress the
per-message hover fill. The fill stays uniform and the accent bar runs full-height.

```css
.showcase-case.open .msg:hover{ background:transparent }
```

Scoped to `.showcase-case.open` (specificity 0,4,0 > global `.msg:hover` 0,2,0) — the global
`.msg:hover` for **real Chat channels is untouched**.

## Goal contract

- **End state:** in an open case, hovering a message shows a uniform fill, no dark-band/lighter-block
  split, and a full-height accent bar.
- **Constraint:** scoped — global `.msg:hover` (real Chat) must not change; non-open showcase cases
  must keep their normal hover block.

## Verification (real browser, dev stack was down → vite + mocked auth; showcase data is static)

| Scenario | Result |
|---|---|
| Open case + hover (before) | dark band on top, lighter split block, half-height stray blue bar — reproduced (`.shots/showcase-before-fix.png`) |
| Open case + hover (after) | **uniform fill, full-height accent bar, no split** (`.shots/showcase-after-fix.png`) |
| Non-open case + hover | **normal canvas-soft rounded block — scoped rule did not touch it** (`.shots/showcase-nonopen-hover.png`) |

- CSSOM (live): `.showcase-case.open .msg:hover → background: transparent` present; specificity beats
  global `.msg:hover`.
- Regression test `test/showcaseOpenHoverHighlight.unit.test.ts` — **3 pass**. Run:
  `npx tsx --test --test-force-exit test/showcaseOpenHoverHighlight.unit.test.ts`. It is a true
  red→green: the rule is absent on `origin/main` (`git show origin/main:web/src/styles.css | grep -c
  'showcase-case.open .msg:hover'` → `0`), so test 1 fails pre-fix.
- `npm run typecheck` — clean.
- Independent verifier (fresh skeptical subagent): **ship**.

## Fail-loud — what was NOT verified

- **No backend was running** (this machine has no `.env`, docker not up), so the dev stack could not
  be started. Showcase rendered via vite + a mocked auth layer; showcase data is fully static
  (`showcaseData.ts`) so this does not affect the rendered result, but it is not a full end-to-end run.
- **Real Chat channel `.msg:hover` not exercised in-browser** (no backend to render a real channel).
  Covered by static guarantee instead: global `.msg:hover` (styles.css L215) is byte-for-byte
  unchanged, and the regression test asserts it stays `var(--canvas-soft)`.
- Screenshots live under `.shots/` (gitignored); they are not embedded here because GitHub image
  attachments require a web upload that the CLI can't do. Before/after/boundary captures are in that
  folder locally.
- The pre-existing impeccable design-system findings in `styles.css` (L157 `#991b1b`, L325/L356 `14px`
  radius) are **not** in this diff and were intentionally left alone (surgical scope) — they predate
  this change and belong to a separate design-system cleanup.
