### PR TITLE
Unify public navigation across marketing pages

### DIFF
--- a/docs-site/src/pages/index.astro
+++ b/docs-site/src/pages/index.astro
@@ -1,5 +1,11 @@
 ---
 import "../styles/docs.css";
+import {
+  GITHUB_URL,
+  PUBLIC_BRAND_MARK_SRC,
+  PUBLIC_NAV_LINKS,
+  resolvePublicNavHref,
+} from "../../../web/src/landing/publicNav";
 
 const quickSteps = [
   {
@@ -40,10 +46,14 @@ curl -X POST "$URL/api/auth/setup" \\
 
 const translations = {
   en: {
+    "nav.features": "Features",
+    "nav.capabilities": "Capabilities",
+    "nav.engines": "Engines",
+    "nav.selfHosted": "Self-hosted",
+    "nav.docs": "Docs",
     "nav.quickstart": "Quickstart",
     "nav.collaboration": "Collaboration",
     "nav.agents": "Agents",
-    "nav.selfHosting": "Self-hosting",
     "side.title": "Browse docs",
     "side.quickstart": "Quickstart",
     "side.firstRun": "First run",
@@ -129,10 +139,14 @@ const translations = {
     "toggle": "中文"
   },
   zh: {
+    "nav.features": "功能",
+    "nav.capabilities": "能力",
+    "nav.engines": "引擎",
+    "nav.selfHosted": "自托管",
+    "nav.docs": "文档",
     "nav.quickstart": "快速开始",
     "nav.collaboration": "协作",
     "nav.agents": "Agents",
-    "nav.selfHosting": "自托管",
     "side.title": "浏览文档",
     "side.quickstart": "快速开始",
     "side.firstRun": "第一次跑通",
@@ -219,6 +233,11 @@ const translations = {
   }
 };
 
+const docsNavLinks = PUBLIC_NAV_LINKS.map((link) => ({
+  ...link,
+  labelKey: `nav.${link.key}`,
+}));
+
 const localizedHead = {
   en: {
     title: "open-tag docs",
@@ -251,21 +270,20 @@ const localizedHead = {
   </head>
   <body>
     <div class="shell">
-      <header class="topbar">
-        <div class="topbar-inner">
-          <a class="brand" href="https://getopentag.com/" aria-label="open-tag home" data-home-link>
-            <img class="brand-mark" src="./favicon.svg" alt="" width="34" height="34" />
-            <span class="brand-word">open-tag</span>
+      <header class="lp-nav">
+        <div class="lp-container lp-nav__inner">
+          <a class="lp-brand" href="https://getopentag.com/" aria-label="open-tag home" data-home-link>
+            <img class="lp-brand-mark" src={PUBLIC_BRAND_MARK_SRC} alt="" width="34" height="34" />
+            <span class="lp-brand-word">open<b>-tag</b></span>
           </a>
-          <nav class="nav" aria-label="Main navigation">
-            <a href="#quickstart" data-i18n="nav.quickstart">Quickstart</a>
-            <a href="#collaboration" data-i18n="nav.collaboration">Collaboration</a>
-            <a href="#agents" data-i18n="nav.agents">Agents</a>
-            <a href="#self-hosting" data-i18n="nav.selfHosting">Self-hosting</a>
+          <nav class="lp-nav__links" aria-label="Main navigation">
+            {docsNavLinks.map((link) => (
+              <a href={resolvePublicNavHref(link, "https://docs.getopentag.com", "docs")} data-public-nav-key={link.key} data-i18n={link.labelKey}>{link.label}</a>
+            ))}
           </nav>
-          <div class="actions">
-            <button class="outline lang" type="button" data-lang-toggle data-i18n="toggle">中文</button>
-            <a class="pill" href="https://github.com/fancyboi999/open-tag">GitHub</a>
+          <div class="lp-nav__cta">
+            <button class="lp-btn lp-btn--ghost lp-btn--sm" type="button" data-lang-toggle data-i18n="toggle">中文</button>
+            <a class="lp-btn lp-btn--primary lp-btn--sm" href={GITHUB_URL}>GitHub</a>
           </div>
         </div>
       </header>
@@ -291,10 +309,10 @@ const localizedHead = {
               <p class="lede" data-i18n="hero.lede">
                 open-tag is a Slack-style workspace for humans and AI agents. Channels, DMs, threads, tasks, files, memory, and live runtime status sit in one place. The server coordinates the work; your machines run the agents.
               </p>
-              <div class="hero-actions">
-                <a class="pill" href="#quickstart" data-i18n="hero.primary">Start the quickstart</a>
-                <a class="outline" href="#self-hosting" data-i18n="hero.secondary">Self-host it</a>
-              </div>
+            <div class="hero-actions">
+                <a class="lp-btn lp-btn--primary" href="#quickstart" data-i18n="hero.primary">Start the quickstart</a>
+                <a class="lp-btn lp-btn--ghost" href="#self-hosting" data-i18n="hero.secondary">Self-host it</a>
+            </div>
             </div>
             <figure class="hero-card">
               <img src="./workspace.png" alt="open-tag workspace with shared channels, agents, tasks, and live activity" loading="eager" />
@@ -490,7 +508,7 @@ npm run daemon</code></pre>
         </div>
       </footer>
     </div>
-    <script define:vars={{ translations, localizedHead }}>
+    <script define:vars={{ translations, localizedHead, docsNavLinks }}>
       const readStoredLanguage = () => {
         try {
           return localStorage.getItem("open-tag-docs-lang");
@@ -516,12 +534,18 @@ npm run daemon</code></pre>
 
       const openedLegacyChineseHash = clearLegacyChineseHash();
 
-      const resolveHomeHref = () => {
-        const origin = window.location.origin;
-        return origin === "https://docs.getopentag.com" ? "https://getopentag.com/" : `${origin}/`;
+      const resolveMarketingHomeHref = (origin) => origin === "https://docs.getopentag.com" ? "https://getopentag.com/" : `${origin}/`;
+      const resolvePublicNavHref = (link, origin) => {
+        if (link.key === "docs") return "#top";
+        return new URL(link.marketingHref, resolveMarketingHomeHref(origin)).toString();
       };
 
-      document.querySelector("[data-home-link]")?.setAttribute("href", resolveHomeHref());
+      document.querySelector("[data-home-link]")?.setAttribute("href", resolveMarketingHomeHref(window.location.origin));
+      document.querySelectorAll("[data-public-nav-key]").forEach((node) => {
+        const key = node.getAttribute("data-public-nav-key");
+        const link = docsNavLinks.find((item) => item.key === key);
+        if (link) node.setAttribute("href", resolvePublicNavHref(link, window.location.origin));
+      });
 
       const applyLanguage = (lang) => {
         const dict = translations[lang] || translations.en;

--- a/docs-site/src/styles/docs.css
+++ b/docs-site/src/styles/docs.css
@@ -1,3 +1,5 @@
+@import "../../../web/src/landing/publicNav.css";
+
 :root {
   --ink: #0c0a09;
   --primary: #292524;
@@ -22,6 +24,30 @@
   --g-sky: #a8c8e8;
   --g-rose: #e8b8c4;
   --shadow-card: 0 24px 80px rgba(12, 10, 9, .08);
+  --lp-bg: var(--canvas);
+  --lp-fg: var(--primary);
+  --lp-fg-2: var(--body);
+  --lp-border: var(--hair);
+  --lp-border-soft: var(--hair-soft);
+  --lp-accent: var(--primary);
+  --lp-accent-on: #fff;
+  --lp-accent-hover: var(--ink);
+  --lp-accent-active: var(--ink);
+  --lp-font-display: "EB Garamond", Georgia, "Times New Roman", serif;
+  --lp-font-body: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --lp-text-sm: 14px;
+  --lp-text-base: 17px;
+  --lp-space-2: 8px;
+  --lp-space-4: 16px;
+  --lp-space-8: 32px;
+  --lp-container-max: 1180px;
+  --lp-gutter: 36px;
+  --lp-public-nav-height: 64px;
+  --lp-radius-pill: 9999px;
+  --lp-focus-ring: 0 0 0 4px rgba(155, 91, 50, 0.24);
+  --lp-motion-fast: 150ms;
+  --lp-motion-base: 240ms;
+  --lp-ease: cubic-bezier(0.2, 0, 0, 1);
   color: var(--ink);
   background: var(--canvas);
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -79,95 +105,6 @@ pre code {
 
 .shell {
   min-height: 100vh;
-}
-
-.topbar {
-  position: sticky;
-  top: 0;
-  z-index: 20;
-  border-bottom: 1px solid rgba(231, 229, 228, .78);
-  background: rgba(245, 245, 245, .86);
-  backdrop-filter: blur(18px);
-}
-
-.topbar-inner {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 24px;
-  width: min(1200px, calc(100% - 48px));
-  height: 64px;
-  margin: 0 auto;
-}
-
-.brand {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  min-width: 0;
-  font-weight: 600;
-}
-
-.brand-mark {
-  width: 34px;
-  height: 34px;
-  border-radius: 50%;
-  object-fit: cover;
-}
-
-.brand-word {
-  font-family: "EB Garamond", Cormorant Garamond, serif;
-  font-size: 24px;
-  font-weight: 300;
-  letter-spacing: 0;
-}
-
-.nav {
-  display: flex;
-  align-items: center;
-  gap: 18px;
-  color: var(--body);
-  font-size: 15px;
-  font-weight: 500;
-}
-
-.nav a:hover {
-  color: var(--ink);
-}
-
-.actions {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.pill,
-.outline {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 40px;
-  border-radius: 9999px;
-  padding: 10px 20px;
-  font-size: 15px;
-  font-weight: 500;
-  white-space: nowrap;
-}
-
-.pill {
-  background: var(--primary);
-  color: #fff;
-}
-
-.outline {
-  border: 1px solid var(--hair-strong);
-  color: var(--ink);
-}
-
-.lang {
-  border: 1px solid var(--hair);
-  background: var(--surface);
-  color: var(--body);
 }
 
 .layout {
@@ -614,7 +551,7 @@ h3 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .nav {
+  .lp-nav__links {
     display: none;
   }
 }
@@ -624,19 +561,14 @@ h3 {
     overflow-x: hidden;
   }
 
-  .topbar-inner,
+  .lp-nav__inner,
   .layout,
   .footer {
     width: min(100% - 28px, 1200px);
   }
 
-  .actions .pill {
+  .lp-nav__cta a.lp-btn {
     display: none;
-  }
-
-  .pill,
-  .outline {
-    padding: 10px 16px;
   }
 
   h1 {

--- a/test/publicNavContract.unit.test.ts
+++ b/test/publicNavContract.unit.test.ts
@@ -1,0 +1,81 @@
+// Unit contract for the public marketing/docs navigation.
+// Run: npx tsx --test --test-force-exit test/publicNavContract.unit.test.ts
+//
+// The public surfaces (/ landing, /features, /docs/) must not each hand-maintain
+// their own brand mark and top-level links. The React pages share a MarketingNav
+// component, and the Astro docs page imports the same public-nav contract.
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const navContract = fs.readFileSync(new URL("../web/src/landing/publicNav.ts", import.meta.url), "utf8");
+const marketingNav = fs.readFileSync(new URL("../web/src/landing/MarketingNav.tsx", import.meta.url), "utf8");
+const landing = fs.readFileSync(new URL("../web/src/views/Landing.tsx", import.meta.url), "utf8");
+const features = fs.readFileSync(new URL("../web/src/views/Features.tsx", import.meta.url), "utf8");
+const docs = fs.readFileSync(new URL("../docs-site/src/pages/index.astro", import.meta.url), "utf8");
+const publicNavCss = fs.readFileSync(new URL("../web/src/landing/publicNav.css", import.meta.url), "utf8");
+const landingCss = fs.readFileSync(new URL("../web/src/landing/landing.css", import.meta.url), "utf8");
+const docsCss = fs.readFileSync(new URL("../docs-site/src/styles/docs.css", import.meta.url), "utf8");
+
+test("public nav source of truth exports the shared brand asset and top-level links", () => {
+  assert.match(navContract, /PUBLIC_BRAND_MARK_SRC\s*=\s*"\/favicon\.svg"/);
+  assert.match(navContract, /GITHUB_URL\s*=\s*"https:\/\/github\.com\/fancyboi999\/open-tag"/);
+  for (const key of ["features", "capabilities", "engines", "selfHosted", "docs"]) {
+    assert.match(navContract, new RegExp(`key:\\s*"${key}"`), `missing shared nav key ${key}`);
+  }
+});
+
+test("landing and features render the shared MarketingNav instead of hand-written nav markup", () => {
+  assert.match(marketingNav, /PUBLIC_NAV_LINKS/);
+  assert.match(marketingNav, /PUBLIC_BRAND_MARK_SRC/);
+  assert.match(marketingNav, /className="lp-brand-mark"/);
+  assert.match(marketingNav, /export function PublicBrand/);
+
+  assert.match(landing, /<MarketingNav[\s\S]*variant="landing"/);
+  assert.match(landing, /<PublicBrand/);
+  assert.doesNotMatch(landing, /<header className="lp-nav">/);
+  assert.doesNotMatch(landing, /open<b>-tag<\/b>/);
+
+  assert.match(features, /<MarketingNav[\s\S]*variant="features"/);
+  assert.doesNotMatch(features, /<header className="lp-nav">/);
+});
+
+test("docs imports the shared public nav contract and renders the shared public-nav visual classes", () => {
+  assert.match(docs, /PUBLIC_NAV_LINKS/);
+  assert.match(docs, /PUBLIC_BRAND_MARK_SRC/);
+  assert.match(docs, /from\s+"..\/..\/..\/web\/src\/landing\/publicNav"/);
+  assert.match(docs, /src=\{PUBLIC_BRAND_MARK_SRC\}/);
+  assert.match(docs, /<header class="lp-nav">/);
+  assert.match(docs, /<div class="lp-container lp-nav__inner">/);
+  assert.match(docs, /class="lp-brand"/);
+  assert.match(docs, /class="lp-brand-mark"/);
+  assert.match(docs, /class="lp-brand-word">open<b>-tag<\/b><\/span>/);
+  assert.match(docs, /class="lp-nav__links"/);
+  assert.match(docs, /class="lp-nav__cta"/);
+  assert.match(docs, /class="lp-btn lp-btn--ghost lp-btn--sm"/);
+  assert.match(docs, /class="lp-btn lp-btn--primary lp-btn--sm"/);
+  assert.doesNotMatch(docs, /src="\.\/favicon\.svg"/);
+  assert.doesNotMatch(docs, /class="topbar/);
+  assert.doesNotMatch(docs, /class="brand"/);
+  assert.doesNotMatch(docs, /class="brand-word"/);
+  assert.doesNotMatch(docs, /class="outline/);
+});
+
+test("marketing and docs headers use the same visual contract", () => {
+  assert.match(landingCss, /@import "\.\/publicNav\.css"/);
+  assert.match(docsCss, /@import "..\/..\/..\/web\/src\/landing\/publicNav\.css"/);
+
+  assert.match(publicNavCss, /\.lp-nav__inner\s*\{[^}]*height:\s*var\(--lp-public-nav-height\)/s);
+  assert.match(publicNavCss, /\.lp-brand-mark\s*\{[^}]*width:\s*34px;[^}]*height:\s*34px/s);
+  assert.match(publicNavCss, /\.lp-brand\s*\{[^}]*font-family:\s*var\(--lp-font-display\);[^}]*font-size:\s*24px;[^}]*letter-spacing:\s*-0\.01em/s);
+  assert.match(publicNavCss, /\.lp-brand-word\s*\{[^}]*transform:\s*translateY\(-1px\)/s);
+  assert.match(publicNavCss, /\.lp-brand b\s*\{[^}]*font-weight:\s*500/s);
+  assert.match(publicNavCss, /\.lp-nav__links\s*\{[^}]*gap:\s*var\(--lp-space-8\)/s);
+  assert.match(publicNavCss, /\.lp-btn--sm\s*\{[^}]*padding:\s*9px 18px;[^}]*font-size:\s*var\(--lp-text-sm\)/s);
+
+  assert.match(docsCss, /--lp-public-nav-height:\s*64px/);
+  assert.doesNotMatch(docsCss, /\.topbar\b/);
+  assert.doesNotMatch(docsCss, /\.brand-word\b/);
+  assert.doesNotMatch(docsCss, /\.pill\b/);
+  assert.doesNotMatch(docsCss, /\.outline\b/);
+});

--- a/web/src/landing/MarketingNav.tsx
+++ b/web/src/landing/MarketingNav.tsx
@@ -1,0 +1,94 @@
+import { Link } from "react-router-dom";
+import {
+  GITHUB_URL,
+  PUBLIC_BRAND_MARK_SRC,
+  PUBLIC_NAV_LINKS,
+  type PublicNavLinkKey,
+  resolvePublicNavHref,
+} from "./publicNav.ts";
+
+type MarketingNavProps = {
+  variant: "landing" | "features";
+  labels?: Partial<Record<PublicNavLinkKey, string>>;
+  githubLabel?: string;
+  enterLabel: string;
+  onEnterWorkspace: () => void;
+  languageToggle?: {
+    label: string;
+    text: string;
+    onClick: () => void;
+  };
+};
+
+type PublicBrandProps = {
+  href?: string;
+  className?: string;
+};
+
+function PublicBrandContent() {
+  return (
+    <>
+      <img className="lp-brand-mark" src={PUBLIC_BRAND_MARK_SRC} alt="" width={34} height={34} />
+      <span className="lp-brand-word">open<b>-tag</b></span>
+    </>
+  );
+}
+
+function GithubIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 .5C5.37.5 0 5.78 0 12.29c0 5.21 3.44 9.63 8.21 11.19.6.11.82-.25.82-.56 0-.28-.01-1.02-.02-2-3.34.71-4.04-1.58-4.04-1.58-.55-1.37-1.33-1.74-1.33-1.74-1.09-.73.08-.72.08-.72 1.2.08 1.84 1.21 1.84 1.21 1.07 1.79 2.81 1.27 3.49.97.11-.76.42-1.27.76-1.56-2.67-.3-5.47-1.31-5.47-5.83 0-1.29.47-2.34 1.24-3.17-.13-.3-.54-1.52.12-3.18 0 0 1.01-.32 3.3 1.21.96-.26 1.98-.39 3-.4 1.02.01 2.04.14 3 .4 2.29-1.53 3.29-1.21 3.29-1.21.66 1.66.25 2.88.12 3.18.77.83 1.24 1.88 1.24 3.17 0 4.53-2.81 5.53-5.49 5.82.43.37.81 1.1.81 2.22 0 1.6-.01 2.9-.01 3.29 0 .31.21.68.83.56C20.56 21.91 24 17.49 24 12.29 24 5.78 18.63.5 12 .5z"/>
+    </svg>
+  );
+}
+
+export function PublicBrand({ href, className = "" }: PublicBrandProps) {
+  const classes = ["lp-brand", className].filter(Boolean).join(" ");
+  if (href) return <a className={classes} href={href} aria-label="open-tag home"><PublicBrandContent /></a>;
+  return <div className={classes}><PublicBrandContent /></div>;
+}
+
+// Shared public-site header for landing and feature pages. Docs imports the same
+// publicNav contract from Astro so top-level links and brand assets do not drift.
+export function MarketingNav({
+  variant,
+  labels = {},
+  githubLabel = "GitHub",
+  enterLabel,
+  onEnterWorkspace,
+  languageToggle,
+}: MarketingNavProps) {
+  const origin = typeof window !== "undefined" && window.location?.origin ? window.location.origin : undefined;
+
+  return (
+    <header className="lp-nav">
+      <div className="lp-container lp-nav__inner">
+        {variant === "landing" ? (
+          <PublicBrand href="#top" />
+        ) : (
+          <Link className="lp-brand" to="/" aria-label="open-tag home">
+            <PublicBrandContent />
+          </Link>
+        )}
+        <nav className="lp-nav__links" aria-label="Main navigation">
+          {PUBLIC_NAV_LINKS.map((link) => (
+            <a key={link.key} href={resolvePublicNavHref(link, origin, "marketing")}>
+              {labels[link.key] ?? link.label}
+            </a>
+          ))}
+        </nav>
+        <div className="lp-nav__cta">
+          {languageToggle && (
+            <button className="lp-btn lp-btn--ghost lp-btn--sm" type="button" onClick={languageToggle.onClick} aria-label={languageToggle.label}>
+              {languageToggle.text}
+            </button>
+          )}
+          <a className="lp-btn lp-btn--ghost lp-btn--sm" href={GITHUB_URL} target="_blank" rel="noreferrer">
+            <GithubIcon /> {githubLabel}
+          </a>
+          <button className="lp-btn lp-btn--primary lp-btn--sm" onClick={onEnterWorkspace}>{enterLabel}</button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/web/src/landing/landing.css
+++ b/web/src/landing/landing.css
@@ -1,3 +1,5 @@
+@import "./publicNav.css";
+
 /* landing.css — skin for the public landing page (/).
  * Source: the `warm-editorial` design system from open-design (tokens.css as the source of truth),
  * re-keyed to the app's DESIGN.md palette so the landing and the app stay visually one.
@@ -47,6 +49,7 @@
   --lp-section-y: 112px;
   --lp-container-max: 1180px;
   --lp-gutter: 36px;
+  --lp-public-nav-height: 64px;
 
   /* —— Radius / elevation / motion —— */
   --lp-radius-xs: 6px; --lp-radius-sm: 10px; --lp-radius-md: 16px; --lp-radius-lg: 24px; --lp-radius-pill: 9999px;
@@ -82,7 +85,6 @@
 .lp-root a { color: inherit; text-decoration: none; }
 
 /* —— Layout primitives —— */
-.lp-container { max-width: var(--lp-container-max); margin: 0 auto; padding-inline: var(--lp-gutter); }
 .lp-section { position: relative; padding-block: var(--lp-section-y); }
 .lp-section--alt { background: var(--lp-bg-2); border-block: 1px solid var(--lp-border-soft); }
 
@@ -141,25 +143,7 @@
 .lp-orb--lavender { animation: lp-orb-drift-lavender 14s cubic-bezier(0.2, 0, 0, 1) -8s infinite; }
 .lp-orb--sky      { animation: lp-orb-drift-sky      18s cubic-bezier(0.2, 0, 0, 1) -12s infinite; }
 
-/* —— Buttons —— */
-.lp-btn { display: inline-flex; align-items: center; gap: var(--lp-space-2); font-family: var(--lp-font-body); font-size: var(--lp-text-base); font-weight: 500; border-radius: var(--lp-radius-pill); padding: 14px 26px; cursor: pointer; transition: background var(--lp-motion-base) var(--lp-ease), border-color var(--lp-motion-base) var(--lp-ease), transform var(--lp-motion-fast) var(--lp-ease); border: 1px solid transparent; }
-.lp-btn:focus-visible { outline: none; box-shadow: var(--lp-focus-ring); }
-.lp-btn--primary { background: var(--lp-accent); color: var(--lp-accent-on); }
-.lp-btn--primary:hover { background: var(--lp-accent-hover); }
-.lp-btn--primary:active { background: var(--lp-accent-active); }
-.lp-btn--ghost { background: transparent; color: var(--lp-fg); border-color: var(--lp-border); }
-.lp-btn--ghost:hover { border-color: var(--lp-fg); }
-.lp-btn--sm { padding: 9px 18px; font-size: var(--lp-text-sm); }
-
 /* —— Nav —— */
-.lp-nav { position: sticky; top: 0; z-index: 20; background: color-mix(in oklab, var(--lp-bg), transparent 12%); backdrop-filter: saturate(1.4) blur(10px); border-bottom: 1px solid var(--lp-border-soft); }
-.lp-nav__inner { display: flex; align-items: center; justify-content: space-between; height: 68px; }
-.lp-brand { font-family: var(--lp-font-display); font-size: 24px; letter-spacing: -0.01em; white-space: nowrap; }
-.lp-brand b { font-weight: 500; }
-.lp-nav__links { display: flex; align-items: center; gap: var(--lp-space-8); }
-.lp-nav__links a { font-size: var(--lp-text-sm); color: var(--lp-fg-2); transition: color var(--lp-motion-fast) var(--lp-ease); }
-.lp-nav__links a:hover { color: var(--lp-accent); }
-.lp-nav__cta { display: flex; align-items: center; gap: var(--lp-space-4); }
 .lp-features .lp-nav { position: relative; }
 
 /* —— Hero —— */

--- a/web/src/landing/publicNav.css
+++ b/web/src/landing/publicNav.css
@@ -1,0 +1,121 @@
+/* Shared public navigation contract for landing, features, and docs. */
+.lp-container {
+  max-width: var(--lp-container-max);
+  margin: 0 auto;
+  padding-inline: var(--lp-gutter);
+}
+
+.lp-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--lp-space-2);
+  font-family: var(--lp-font-body);
+  font-size: var(--lp-text-base);
+  font-weight: 500;
+  border: 1px solid transparent;
+  border-radius: var(--lp-radius-pill);
+  padding: 14px 26px;
+  cursor: pointer;
+  transition:
+    background var(--lp-motion-base) var(--lp-ease),
+    border-color var(--lp-motion-base) var(--lp-ease),
+    transform var(--lp-motion-fast) var(--lp-ease);
+}
+
+.lp-btn:focus-visible {
+  outline: none;
+  box-shadow: var(--lp-focus-ring);
+}
+
+.lp-btn--primary {
+  background: var(--lp-accent);
+  color: var(--lp-accent-on);
+}
+
+.lp-btn--primary:hover {
+  background: var(--lp-accent-hover);
+}
+
+.lp-btn--primary:active {
+  background: var(--lp-accent-active);
+}
+
+.lp-btn--ghost {
+  background: transparent;
+  color: var(--lp-fg);
+  border-color: var(--lp-border);
+}
+
+.lp-btn--ghost:hover {
+  border-color: var(--lp-fg);
+}
+
+.lp-btn--sm {
+  padding: 9px 18px;
+  font-size: var(--lp-text-sm);
+}
+
+.lp-nav {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: color-mix(in oklab, var(--lp-bg), transparent 12%);
+  backdrop-filter: saturate(1.4) blur(10px);
+  border-bottom: 1px solid var(--lp-border-soft);
+}
+
+.lp-nav__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--lp-public-nav-height);
+}
+
+.lp-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--lp-font-display);
+  font-size: 24px;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+}
+
+.lp-brand-mark {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex: 0 0 auto;
+}
+
+.lp-brand-word {
+  display: inline-block;
+  transform: translateY(-1px);
+}
+
+.lp-brand b {
+  font-weight: 500;
+}
+
+.lp-nav__links {
+  display: flex;
+  align-items: center;
+  gap: var(--lp-space-8);
+}
+
+.lp-nav__links a {
+  font-size: var(--lp-text-sm);
+  color: var(--lp-fg-2);
+  transition: color var(--lp-motion-fast) var(--lp-ease);
+}
+
+.lp-nav__links a:hover {
+  color: var(--lp-accent);
+}
+
+.lp-nav__cta {
+  display: flex;
+  align-items: center;
+  gap: var(--lp-space-4);
+}

--- a/web/src/landing/publicNav.ts
+++ b/web/src/landing/publicNav.ts
@@ -1,0 +1,37 @@
+export const GITHUB_URL = "https://github.com/fancyboi999/open-tag";
+export const MARKETING_SITE_URL = "https://getopentag.com";
+export const DOCS_SITE_URL = "https://docs.getopentag.com/";
+export const PUBLIC_BRAND_MARK_SRC = "/favicon.svg";
+
+export const MARKETING_ORIGINS = new Set([MARKETING_SITE_URL, "https://www.getopentag.com"]);
+
+export type PublicNavLinkKey = "features" | "capabilities" | "engines" | "selfHosted" | "docs";
+
+export type PublicNavLink = {
+  key: PublicNavLinkKey;
+  label: string;
+  marketingHref: string;
+};
+
+export const PUBLIC_NAV_LINKS: PublicNavLink[] = [
+  { key: "features", label: "Features", marketingHref: "/features" },
+  { key: "capabilities", label: "Capabilities", marketingHref: "/#capabilities" },
+  { key: "engines", label: "Engines", marketingHref: "/#engines" },
+  { key: "selfHosted", label: "Self-hosted", marketingHref: "/#self-hosted" },
+  { key: "docs", label: "Docs", marketingHref: "/docs/" },
+];
+
+export function resolveDocsHref(origin = MARKETING_SITE_URL): string {
+  return MARKETING_ORIGINS.has(origin) ? DOCS_SITE_URL : `${origin}/docs/`;
+}
+
+export function resolveMarketingHomeHref(origin = MARKETING_SITE_URL): string {
+  return origin === DOCS_SITE_URL.slice(0, -1) ? `${MARKETING_SITE_URL}/` : `${origin}/`;
+}
+
+export function resolvePublicNavHref(link: PublicNavLink, origin = MARKETING_SITE_URL, surface: "marketing" | "docs" = "marketing"): string {
+  if (surface === "marketing") return link.key === "docs" ? resolveDocsHref(origin) : link.marketingHref;
+  if (link.key === "docs") return "#top";
+  const home = resolveMarketingHomeHref(origin);
+  return new URL(link.marketingHref, home).toString();
+}

--- a/web/src/views/Features.tsx
+++ b/web/src/views/Features.tsx
@@ -10,6 +10,8 @@ import {
 } from "lucide-react";
 import { useStore } from "../store.tsx";
 import { ProductMock, type ProductMockCase } from "./ProductMock.tsx";
+import { MarketingNav } from "../landing/MarketingNav.tsx";
+import { GITHUB_URL } from "../landing/publicNav.ts";
 import "../landing/landing.css";
 
 declare module "react" {
@@ -25,8 +27,6 @@ declare module "react" {
   }
 }
 
-const GITHUB_URL = "https://github.com/fancyboi999/open-tag";
-const MARKETING_ORIGINS = new Set(["https://getopentag.com", "https://www.getopentag.com"]);
 const DIALOGUE_LOTTIE_URL = "https://cdn.prod.website-files.com/6889473510b50328dbb70ae6/69423930508a9aa8996cc590_Object-Dialogue.lottie";
 const DOT_LOTTIE_PLAYER_SRC = "https://unpkg.com/@dotlottie/player-component@2.7.12/dist/dotlottie-player.mjs";
 
@@ -75,11 +75,6 @@ type FeatureCopy = {
     github: string;
   };
 };
-
-function docsUrl(): string {
-  const origin = typeof window !== "undefined" && window.location?.origin ? window.location.origin : "https://getopentag.com";
-  return MARKETING_ORIGINS.has(origin) ? "https://docs.getopentag.com/" : `${origin}/docs/`;
-}
 
 export function currentLang(language?: string): Lang {
   return language?.toLowerCase().startsWith("zh") ? "zh" : "en";
@@ -536,7 +531,6 @@ export function Features() {
   const [activeId, setActiveId] = useState(cases[0]!.id);
   const active = useMemo(() => cases.find((c) => c.id === activeId) ?? cases[0]!, [activeId, cases]);
   const enterWorkspace = () => navigate(me ? `/s/${slug}/channel` : "/login");
-  const docsHref = docsUrl();
   const nextLang: Lang = lang === "en" ? "zh" : "en";
   const switchLanguage = () => {
     void i18n.changeLanguage(nextLang);
@@ -559,27 +553,24 @@ export function Features() {
 
   return (
     <main className="lp-root lp-features">
-      <header className="lp-nav">
-        <div className="lp-container lp-nav__inner">
-          <Link className="lp-brand" to="/">open<b>-tag</b></Link>
-          <nav className="lp-nav__links">
-            <Link to="/features">{copy.nav.features}</Link>
-            <a href="/#capabilities">{copy.nav.capabilities}</a>
-            <a href="/#engines">{copy.nav.engines}</a>
-            <a href="/#self-hosted">{copy.nav.selfHosted}</a>
-            <a href={docsHref}>{copy.nav.docs}</a>
-          </nav>
-          <div className="lp-nav__cta">
-            <button className="lp-btn lp-btn--ghost lp-btn--sm" type="button" onClick={switchLanguage} aria-label={copy.nav.languageLabel}>
-              {lang === "en" ? "中文" : "EN"}
-            </button>
-            <a className="lp-btn lp-btn--ghost lp-btn--sm" href={GITHUB_URL} target="_blank" rel="noreferrer">
-              <GithubIcon size={16} /> {copy.nav.github}
-            </a>
-            <button className="lp-btn lp-btn--primary lp-btn--sm" onClick={enterWorkspace}>{copy.nav.enter}</button>
-          </div>
-        </div>
-      </header>
+      <MarketingNav
+        variant="features"
+        labels={{
+          features: copy.nav.features,
+          capabilities: copy.nav.capabilities,
+          engines: copy.nav.engines,
+          selfHosted: copy.nav.selfHosted,
+          docs: copy.nav.docs,
+        }}
+        githubLabel={copy.nav.github}
+        enterLabel={copy.nav.enter}
+        onEnterWorkspace={enterWorkspace}
+        languageToggle={{
+          label: copy.nav.languageLabel,
+          text: lang === "en" ? "中文" : "EN",
+          onClick: switchLanguage,
+        }}
+      />
 
       <section className="lp-feature-hero">
         <div className="lp-container lp-feature-hero__grid">

--- a/web/src/views/Landing.tsx
+++ b/web/src/views/Landing.tsx
@@ -11,15 +11,9 @@ import {
 import { useStore } from "../store.tsx";
 import { COPY as FEATURE_COPY, currentLang, type Lang } from "./Features.tsx";
 import { ProductMock } from "./ProductMock.tsx";
+import { MarketingNav, PublicBrand } from "../landing/MarketingNav.tsx";
+import { GITHUB_URL, resolveDocsHref } from "../landing/publicNav.ts";
 import "../landing/landing.css";
-
-const GITHUB_URL = "https://github.com/fancyboi999/open-tag";
-const MARKETING_ORIGINS = new Set(["https://getopentag.com", "https://www.getopentag.com"]);
-
-function docsUrl(): string {
-  const origin = typeof window !== "undefined" && window.location?.origin ? window.location.origin : "https://getopentag.com";
-  return MARKETING_ORIGINS.has(origin) ? "https://docs.getopentag.com/" : `${origin}/docs/`;
-}
 
 function detectLandingLang(): Lang {
   if (typeof window === "undefined") return "en";
@@ -306,13 +300,14 @@ export function Landing() {
   const navigate = useNavigate();
   const [lang, setLang] = useState<Lang>(() => detectLandingLang());
   const enterWorkspace = () => navigate(me ? `/s/${slug}/channel` : "/login");
-  const docsHref = docsUrl();
   const copy = LANDING_COPY[lang];
   const nextLang: Lang = lang === "en" ? "zh" : "en";
   const switchLanguage = () => {
     setLang(nextLang);
     try { localStorage.setItem("open-tag.lang", nextLang); } catch { /* ignore */ }
   };
+  const origin = typeof window !== "undefined" && window.location?.origin ? window.location.origin : undefined;
+  const docsHref = resolveDocsHref(origin);
 
   // Scroll reveal: add is-visible once a section enters the viewport (one-shot); reduced-motion falls back to visible via CSS.
   useEffect(() => {
@@ -327,28 +322,24 @@ export function Landing() {
 
   return (
     <main className="lp-root">
-      {/* —— Nav —— */}
-      <header className="lp-nav">
-        <div className="lp-container lp-nav__inner">
-          <a className="lp-brand" href="#top">open<b>-tag</b></a>
-          <nav className="lp-nav__links">
-            <Link to="/features">{copy.nav.features}</Link>
-            <a href="#capabilities">{copy.nav.capabilities}</a>
-            <a href="#engines">{copy.nav.engines}</a>
-            <a href="#self-hosted">{copy.nav.selfHosted}</a>
-            <a href={docsHref}>{copy.nav.docs}</a>
-          </nav>
-          <div className="lp-nav__cta">
-            <button className="lp-btn lp-btn--ghost lp-btn--sm" type="button" onClick={switchLanguage} aria-label={copy.nav.languageLabel}>
-              {lang === "en" ? "中文" : "EN"}
-            </button>
-            <a className="lp-btn lp-btn--ghost lp-btn--sm" href={GITHUB_URL} target="_blank" rel="noreferrer">
-              <GithubIcon size={16} /> {copy.nav.github}
-            </a>
-            <button className="lp-btn lp-btn--primary lp-btn--sm" onClick={enterWorkspace}>{copy.nav.enter}</button>
-          </div>
-        </div>
-      </header>
+      <MarketingNav
+        variant="landing"
+        labels={{
+          features: copy.nav.features,
+          capabilities: copy.nav.capabilities,
+          engines: copy.nav.engines,
+          selfHosted: copy.nav.selfHosted,
+          docs: copy.nav.docs,
+        }}
+        githubLabel={copy.nav.github}
+        enterLabel={copy.nav.enter}
+        onEnterWorkspace={enterWorkspace}
+        languageToggle={{
+          label: copy.nav.languageLabel,
+          text: lang === "en" ? "中文" : "EN",
+          onClick: switchLanguage,
+        }}
+      />
 
       {/* —— Hero —— */}
       <section className="lp-hero" id="top">
@@ -506,7 +497,7 @@ export function Landing() {
         <div className="lp-container lp-reveal">
           <div className="lp-footer__grid">
             <div className="lp-footer__brand">
-              <div className="lp-brand">open<b>-tag</b></div>
+              <PublicBrand />
               <p className="lp-footer__tagline">{copy.footer.tagline}</p>
             </div>
             <div className="lp-footer__col">


### PR DESCRIPTION
## Summary
- Adds a shared public-nav contract for landing, features, and docs.
- Replaces hand-maintained landing/features headers with `MarketingNav` and shared brand/link constants.
- Updates the Astro docs header to use the same `lp-nav` visual classes and shared logo/link contract.
- Adds a unit contract test to catch future drift in brand mark, nav links, and visual class usage.

## Verification
- `npx tsx --test --test-force-exit test/publicNavContract.unit.test.ts`
- `npm run typecheck`
- `npm run web:build`
- `npm run docs:build`
- In-app browser real page check on `http://localhost:7801/`, `/features`, and `/docs/`:
  - all three rendered `headerClass: "lp-nav"`
  - all three rendered `innerClass: "lp-container lp-nav__inner"`
  - all three used `/favicon.svg`
  - all three had no legacy `.topbar-inner`
  - all three matched brand font, 24px size, -0.24px letter spacing, 10px brand gap, 32px nav gap, and `translateY(-1px)` wordmark alignment

## Notes
- Rebased on current `origin/main` and resolved conflicts in `Landing.tsx` / `Features.tsx` by keeping the latest landing language behavior while switching the header to shared public nav.
