### PR TITLE
fix(log): keep non-error server logs off stderr

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -86,7 +86,7 @@ Lets any machine join a server without cloning the repo: `npx @fancyboi999/open-
 - `db/index.ts` / `db/seed.ts` — DB handle (drizzle + postgres) / seed data.
 - `redis.ts` — `nextSeq` (INCR `seq:{server}`) / `nextTaskNumber(serverId, channel?)` (INCR a scope key from `taskNumberKey`: `tasknum:dm:{channelId}` for DMs, `tasknum:{server}` otherwise) / `reconcileCounters` (boot-time durability guard: advances seq + every task-number scope to the live Postgres max) / `publishEvent` (pub/sub real-time fan-out, SSE subscribes `events:{server}`) / `pokeAgent` (RPUSH `wake:{agentId}`, wakes agent's BLPOP long-poll).
 - `env.ts` — Loads root `.env` (**must be the first import** in any module that reads `process.env`; does not override variables already set in the shell environment).
-- `log.ts` — Unified logger writing to `~/.open-tag/logs/`.
+- `log.ts` — Unified logger writing JSONL to `~/.open-tag/logs/` and human-readable console lines to stdout/stderr: non-error server/daemon logs go to stdout so platform loggers do not classify debug/info as errors, true errors go to stderr, and CLI logs stay on stderr so agent-readable command stdout remains clean.
 - `daemonProtocol.ts` — Shared daemon ↔ server WS control-plane constants (e.g. `MACHINE_REJECTED_CODE` = WS close `4001`), imported by **both** `server/ws.ts` and `daemon/connection.ts` so the wire contract has a single source of truth.
 - `cli/index.ts` — **`open-tag` CLI**: subcommand tree mirroring `/agent-api` (message / channel / task / thread / profile / reminder / attachment / search / server / action), directly `fetch(OPEN_TAG_SERVER_URL + /agent-api/...)` with Bearer `OPEN_TAG_AGENT_TOKEN` (per-agent token injected by daemon) + `x-agent-id`. Note: `open-tag message check` is non-blocking; there is **no** `receive` command. `open-tag action prepare --target <ch>` reads action JSON from stdin and posts a card.
 
@@ -156,7 +156,7 @@ cd web && npm run dev  # Vite HMR dev server
 ## V. Cross-cutting concerns
 
 - `env.ts` must be imported before any module that reads `process.env`.
-- `log.ts` spans all three planes; logs land in `~/.open-tag/logs/`.
+- `log.ts` spans all three planes; JSONL logs land in `~/.open-tag/logs/`, while console streams are split so platform logs and CLI stdout semantics stay usable.
 - `redis.ts` seq / task-number / pub-sub / wake queue are shared infrastructure for real-time and sync.
 - `auth.ts` (human/agent) + `ws.ts` (daemon key) + `scopes.ts` (agent permissions) + `capabilities.ts` (human role permissions) are enforced across all routes.
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -27,8 +27,8 @@ export function createLogger(component: string): Logger {
     try { fs.appendFileSync(file, JSON.stringify(rec) + "\n"); } catch { /* */ }
     const extra = fields && Object.keys(fields).length ? " " + safeJson(fields) : "";
     const line = `${rec.t} ${level.toUpperCase().padEnd(5)} [${component}] ${msg}${extra}`;
-    // Always write to stderr: keeps CLI stdout clean (agents only read command results from stdout)
-    try { process.stderr.write(line + "\n"); } catch { /* */ }
+    const stream = consoleStream(component, level);
+    try { stream.write(line + "\n"); } catch { /* */ }
   }
   return {
     debug: (m, f) => write("debug", m, f),
@@ -37,6 +37,11 @@ export function createLogger(component: string): Logger {
     error: (m, f) => write("error", m, f),
     child: (sub) => createLogger(`${component}:${sub}`),
   };
+}
+
+function consoleStream(component: string, level: Level): NodeJS.WriteStream {
+  if (level === "error" || component === "cli" || component.startsWith("cli:")) return process.stderr;
+  return process.stdout;
 }
 
 function safeJson(o: unknown): string {

--- a/test/logStreams.unit.test.ts
+++ b/test/logStreams.unit.test.ts
@@ -1,0 +1,53 @@
+// Railway classifies stderr as error-level logs. Server/daemon debug/info/warn
+// lines must therefore go to stdout, while the CLI keeps all logger output on
+// stderr so command stdout remains machine-readable for agents.
+//
+// Run: npx tsx --test --test-force-exit test/logStreams.unit.test.ts
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createLogger } from "../src/log.ts";
+
+function captureWrites(fn: () => void): { stdout: string; stderr: string } {
+  let stdout = "";
+  let stderr = "";
+  const oldStdout = process.stdout.write;
+  const oldStderr = process.stderr.write;
+  (process.stdout.write as any) = (chunk: unknown) => { stdout += String(chunk); return true; };
+  (process.stderr.write as any) = (chunk: unknown) => { stderr += String(chunk); return true; };
+  try {
+    fn();
+  } finally {
+    process.stdout.write = oldStdout;
+    process.stderr.write = oldStderr;
+  }
+  return { stdout, stderr };
+}
+
+test("server debug/info/warn logs write to stdout, not stderr", () => {
+  const out = captureWrites(() => {
+    const log = createLogger("server");
+    log.debug("req", { path: "/health", status: 200 });
+    log.info("control plane up");
+    log.warn("transient warning");
+  });
+
+  assert.match(out.stdout, /DEBUG\s+\[server\] req/);
+  assert.match(out.stdout, /INFO\s+\[server\] control plane up/);
+  assert.match(out.stdout, /WARN\s+\[server\] transient warning/);
+  assert.equal(out.stderr, "");
+});
+
+test("server errors still write to stderr", () => {
+  const out = captureWrites(() => createLogger("server").error("request error"));
+
+  assert.equal(out.stdout, "");
+  assert.match(out.stderr, /ERROR\s+\[server\] request error/);
+});
+
+test("cli logger output stays on stderr to keep command stdout clean", () => {
+  const out = captureWrites(() => createLogger("cli").debug("api", { status: 200 }));
+
+  assert.equal(out.stdout, "");
+  assert.match(out.stderr, /DEBUG\s+\[cli\] api/);
+});


### PR DESCRIPTION
## Goal contract

End state: normal server/daemon debug/info/warn console logs no longer go to stderr, so Railway does not classify routine request DEBUG logs as error-level logs. True errors still go to stderr. CLI logger output remains on stderr so `open-tag` command stdout stays machine-readable for agents.

Constraints:
- Do not change JSONL file logging behavior.
- Do not pollute CLI stdout.
- No production deploy/restart in this PR.

## What changed

- `src/log.ts` now chooses the console stream by component and level:
  - `error` -> stderr
  - `cli` / `cli:*` -> stderr
  - non-error server/daemon/other components -> stdout
- Added `test/logStreams.unit.test.ts` for server stdout, server error stderr, and CLI stderr behavior.
- Updated `ARCHITECTURE.md` to document the console stream split.

## Verification

RED before fix:

```text
npx tsx --test --test-force-exit test/logStreams.unit.test.ts
# FAIL: server debug/info/warn logs write to stdout, not stderr
# stdout was empty because src/log.ts wrote every line to stderr
```

After fix:

```text
npx tsx --test --test-force-exit test/logStreams.unit.test.ts
# Pass: 3 tests, 3 pass

npm run typecheck
# Pass: root + web TypeScript checks

set -a && . ./.env && set +a && npx tsx --test --test-force-exit test/*.unit.test.ts
# Pass: 186 tests, 186 pass

npm run web:build
# Pass: vite build + prerender completed
```

Real local server channel:

```text
set -a && . ./.env && set +a && npm run server > /tmp/open-tag-log-streams.stdout 2> /tmp/open-tag-log-streams.stderr
curl http://localhost:7801/health
# {"ok":true,"service":"open-tag",...}

stdout contained:
2026-06-27T05:33:35.309Z DEBUG [server] req {"method":"GET","path":"/health","status":200,"ms":1}

stderr was empty for that request.
```

## Independent verifier

Verifier verdict: PASS for behavior, WARN for branch readiness. The warning was that `test/logStreams.unit.test.ts` was untracked at verification time; it is included in commit `a81894b`.

Verifier also confirmed:
- `npx tsx --test --test-force-exit test/logStreams.unit.test.ts` passes.
- `npm run typecheck` passes.
- Full unit suite passes with `.env` sourced: 186/186.
- Real server run with stdout/stderr files puts `/health` DEBUG request in stdout and leaves stderr 0 bytes.
- JSONL file logging still writes server log entries under `OPEN_TAG_HOME=/tmp/.../logs/server.log`.
- CLI `--help` keeps help text on stdout and stderr empty.
- `ARCHITECTURE.md` documents the split.

## Fail loud

Skipped:
- Production deploy/restart and live Railway post-fix log validation.
- Live daemon process verification; daemon behavior follows shared logger routing and is covered by component-level tests.
- Successful authenticated CLI API command; CLI no-server `--help`, source inspection, and logger unit tests cover stdout cleanliness.

Warnings:
- Full unit suite needs `.env` sourced in this shell; without it auth-related tests fail loudly on missing `JWT_SECRET`.
- First `git push` attempt hung and was interrupted (`git-remote-https died of signal 9`); a clean retry succeeded.

Not verified:
- Railway's post-deploy log classifier after merge/deploy.
