### PR TITLE
fix(web): compare daemon versions semantically

### DIFF
--- a/web/src/alerts.test.ts
+++ b/web/src/alerts.test.ts
@@ -1,0 +1,16 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isDaemonOutdated } from "./alerts.tsx";
+
+test("daemon is outdated only when its semantic version is lower than latest", () => {
+  assert.equal(isDaemonOutdated("0.6.0", "0.6.1"), true);
+  assert.equal(isDaemonOutdated("0.6.1", "0.6.1"), false);
+  assert.equal(isDaemonOutdated("0.6.1", "0.6.0"), false);
+});
+
+test("unknown or non-semver daemon versions are not treated as outdated", () => {
+  assert.equal(isDaemonOutdated("", "0.6.1"), false);
+  assert.equal(isDaemonOutdated("dev", "0.6.1"), false);
+  assert.equal(isDaemonOutdated("0.6.0", ""), false);
+  assert.equal(isDaemonOutdated("0.6.0", "dev"), false);
+});

--- a/web/src/alerts.tsx
+++ b/web/src/alerts.tsx
@@ -18,14 +18,32 @@ export interface SystemAlert {
   machineId?: string;    // when set, the "View" action navigates to this computer
 }
 
+export function isDaemonOutdated(current: string | undefined, latest: string | undefined): boolean {
+  const cur = parseSemver(current);
+  const next = parseSemver(latest);
+  if (!cur || !next) return false;
+  for (let i = 0; i < 3; i++) {
+    if (cur[i]! < next[i]!) return true;
+    if (cur[i]! > next[i]!) return false;
+  }
+  return false;
+}
+
+function parseSemver(v: string | undefined): [number, number, number] | null {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(v ?? "");
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
 export function useSystemAlerts(): SystemAlert[] {
   const { machines, agents, latestDaemonVersion } = useStore();
   const { t } = useTranslation();
   return useMemo(() => {
     const out: SystemAlert[] = [];
     // Outdated daemon: only flag *online* machines (an offline one isn't running anything to be outdated) whose
-    // reported version differs from the latest published one. Grouped into one alert listing every stale machine.
-    const outdated = machines.filter((m) => m.status === "online" && m.daemonVersion && latestDaemonVersion && m.daemonVersion !== latestDaemonVersion);
+    // reported semver is lower than the latest published one. A newer daemon can briefly connect to an older
+    // server during release rollout; that is not outdated and should not page the operator.
+    const outdated = machines.filter((m) => m.status === "online" && isDaemonOutdated(m.daemonVersion, latestDaemonVersion));
     if (outdated.length) {
       const names = outdated.map((m) => m.name || m.hostname || m.id).join(", ");
       out.push({


### PR DESCRIPTION
## Goal

Stop the outdated-daemon alert from firing when a machine is running a newer daemon than the server's currently deployed `latestDaemonVersion`.

## Root cause

The alert used string inequality (`daemonVersion !== latestDaemonVersion`). During rollout, macmini can run `0.6.1` while the server still reports `0.6.0`; inequality incorrectly labels that newer daemon as outdated.

## Changes

- Add `isDaemonOutdated(current, latest)` with numeric semver comparison.
- Only alert when `current < latest`.
- Treat unknown/non-semver versions (`dev`, empty) as non-outdated to avoid noisy false positives.
- Add regression tests for older/equal/newer and unknown version cases.

## Verification

- `npx tsx --test --test-force-exit web/src/alerts.test.ts` -> 2 pass
- `npm run typecheck` -> pass
- `npm --prefix web run build` -> pass
- `git diff --check` -> pass

## Fail loud

Skipped: live browser verification against getopentag production; this is a pure alert predicate fix and was covered with unit tests + production web build.

Warnings: none from the final verification commands.

Not verified: production alert disappearance after deploy. It requires merging this PR and redeploying getopentag.
