### PR TITLE
fix(daemon): Windows compatibility for runtime detection and process spawning

### DIFF
--- a/src/daemon/claudeRuntime.ts
+++ b/src/daemon/claudeRuntime.ts
@@ -1,6 +1,7 @@
 // claude runtime: `claude -p stream-json` continuous session. User messages are written to stdin to drive turns;
 // stdout is parsed as stream-json events.
 import { spawn } from "node:child_process";
+import { resolveBin } from "./runtimes.js";
 import { writeFileSync } from "node:fs";
 import path from "node:path";
 import type { Runtime, StartOpts, RuntimeCallbacks, RuntimeSession, TrajectoryEntry } from "./runtime.js";
@@ -30,7 +31,7 @@ export const claudeRuntime: Runtime = {
     ];
     if (opts.sessionId) args.push("--resume", opts.sessionId);
 
-    const proc = spawn("claude", args, { cwd: opts.cwd, stdio: ["pipe", "pipe", "pipe"], env: opts.env });
+    const proc = spawn(resolveBin("claude"), args, { cwd: opts.cwd, stdio: ["pipe", "pipe", "pipe"], env: opts.env });
     let sessionId = opts.sessionId ?? null;
     const writeUser = (text: string) => {
       const m = { type: "user", message: { role: "user", content: [{ type: "text", text }] }, ...(sessionId ? { session_id: sessionId } : {}) };

--- a/src/daemon/codexRuntime.ts
+++ b/src/daemon/codexRuntime.ts
@@ -2,6 +2,7 @@
 // System prompt is passed via developerInstructions; each delivery = one turn/start (serial, waits for turn/completed).
 // Automatically approves exec/patch/elicitation requests in daemon mode.
 import { spawn, type ChildProcess } from "node:child_process";
+import { resolveBin } from "./runtimes.js";
 import type { Runtime, StartOpts, RuntimeCallbacks, RuntimeSession } from "./runtime.js";
 
 const MAX = 2000;
@@ -131,7 +132,7 @@ export const codexRuntime: Runtime = {
   start(opts: StartOpts, cb: RuntimeCallbacks): RuntimeSession {
     // Do not override CODEX_HOME: use the user's default ~/.codex (which contains subscription auth state).
     // Per-agent CODEX_HOME isolation + auth/MCP injection is a future improvement.
-    const proc = spawn("codex", ["app-server", "--listen", "stdio://"], { cwd: opts.cwd, stdio: ["pipe", "pipe", "pipe"], env: opts.env });
+    const proc = spawn(resolveBin("codex"), ["app-server", "--listen", "stdio://"], { cwd: opts.cwd, stdio: ["pipe", "pipe", "pipe"], env: opts.env });
     const client = new CodexClient(proc, cb);
     let ready = false;
     const queue: string[] = [];

--- a/src/daemon/copilotRuntime.ts
+++ b/src/daemon/copilotRuntime.ts
@@ -5,6 +5,7 @@
 // system prompt is injected via {cwd}/AGENTS.md, which Copilot reads natively.
 // Protocol verified against GitHub Copilot CLI 1.0.61 (see src/daemon/__fixtures__/copilot-*.jsonl).
 import { spawn, type ChildProcess } from "node:child_process";
+import { resolveBin } from "./runtimes.js";
 import { randomUUID } from "node:crypto";
 import { writeFileSync } from "node:fs";
 import path from "node:path";
@@ -118,7 +119,7 @@ class CopilotRun {
     this.turnBusy = true;
     this.cb.onActivity("working", "turn");
     const args = buildArgs(prompt, this.sessionId, this.opts.model, reasoningEffort(this.opts.runtimeConfig));
-    const proc = spawn("copilot", args, { cwd: this.opts.cwd, stdio: ["ignore", "pipe", "pipe"], env: this.env });
+    const proc = spawn(resolveBin("copilot"), args, { cwd: this.opts.cwd, stdio: ["ignore", "pipe", "pipe"], env: this.env });
     this.proc = proc;
     let buf = "";
     let resultSeen = false;

--- a/src/daemon/listModels.ts
+++ b/src/daemon/listModels.ts
@@ -10,6 +10,7 @@
 // The parse functions are pure (unit-tested against fixtures captured from multica's discovery
 // research) and mirror multica's server/pkg/agent/models.go field-for-field.
 import { spawn, type ChildProcess } from "node:child_process";
+import { resolveBin } from "./runtimes.js";
 
 export interface ThinkingLevel { value: string; label: string; description?: string }
 export interface ModelThinking { levels: ThinkingLevel[]; default?: string }
@@ -174,7 +175,7 @@ function runList(bin: string, args: string[], timeoutMs: number = LIST_TIMEOUT_M
     delete env.NODE_OPTIONS;
     let proc: ChildProcess;
     try {
-      proc = spawn(bin, args, { stdio: ["ignore", "pipe", "pipe"], env });
+      proc = spawn(resolveBin(bin), args, { stdio: ["ignore", "pipe", "pipe"], env });
     } catch (e) {
       return resolve({ stdout: "", stderr: String((e as any)?.message ?? e), code: 1 });
     }

--- a/src/daemon/runtimes.ts
+++ b/src/daemon/runtimes.ts
@@ -11,7 +11,54 @@ import type { Runtime } from "./runtime.js";
 
 export type { Runtime, RuntimeSession, RuntimeCallbacks, StartOpts, TrajectoryEntry } from "./runtime.js";
 
-function has(tool: string): boolean { try { execSync(`command -v ${tool}`, { stdio: "pipe" }); return true; } catch { return false; } }
+// ── Cross-platform binary resolution ─────────────────────────────
+// On Windows, `spawn("claude")` fails because npm installs .cmd shims and
+// CreateProcessW doesn't resolve PATHEXT for bare names. We use `where` to
+// locate the binary and, if it's a .cmd/.ps1 wrapper, read it to find the
+// underlying .exe. On Unix this is a no-op pass-through.
+export function resolveBin(tool: string): string {
+  if (process.platform !== "win32") return tool;
+  try {
+    const raw = execSync(`where ${tool}`, { encoding: "utf8", stdio: "pipe" }).trim();
+    const lines = raw.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+    for (const p of lines) {
+      if (/\.(cmd|bat|ps1)$/i.test(p)) {
+        try {
+          const content = execSync(`type "${p}"`, { encoding: "utf8", stdio: "pipe" }).trim();
+          const m = content.match(/["']([^"']+\.exe)["']/);
+          if (m) {
+            const exePath = m[1].replace(/%\w+%/g, "");
+            const resolved = /^[A-Za-z]:/.test(exePath)
+              ? exePath
+              : `${p.replace(/[\/][^\/]+$/, "")}/${exePath}`;
+            if (require("node:fs").existsSync(resolved)) return resolved;
+          }
+        } catch { /* fall through */ }
+      } else if (/\.exe$/i.test(p)) {
+        return p;
+      }
+    }
+    // where returned extensionless shim path — try appending .exe
+    for (const l of lines) {
+      const exe = l + ".exe";
+      if (require("node:fs").existsSync(exe)) return exe;
+    }
+    return lines[0] || tool;
+  } catch {
+    return tool;
+  }
+}
+
+function has(tool: string): boolean {
+  try {
+    // Use `where` on Windows (cmd.exe doesn't have `command -v`), `command -v` on Unix.
+    const cmd = process.platform === "win32" ? "where" : "command -v";
+    execSync(`${cmd} ${tool}`, { stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
+}
 export function detectRuntimes(): string[] {
   return ["claude", "codex", "copilot", "kimi", "opencode", "pi", "cursor-agent"].filter(has).map((t) => (t === "cursor-agent" ? "cursor" : t));
 }


### PR DESCRIPTION
## 中文说明

两个 Windows 平台兼容性修复 / Two Windows compatibility fixes：

### 问题 1: 运行时检测返回空数组

\`detectRuntimes()\` 使用 \`command -v\`（bash 内建命令）检测 agent CLI 是否安装。在 Windows 上，Node.js 默认使用 \`cmd.exe\`，不识别该命令，导致所有运行时报告为 \`runtimes: []\`。

**修复:** Windows 上改用 \`where\`，Unix 上保持 \`command -v\`。

### 问题 2: spawn 报 ENOENT

npm 安装的 CLI 是 \`.cmd\` shim，Windows 的 \`CreateProcessW\` 不会为裸名称解析 PATHEXT，导致 \`spawn("claude")\` 直接报错退出。

**修复:** 新增 \`resolveBin()\` 辅助函数，通过 \`where\` 定位二进制文件，读取 \`.cmd\`/\`.ps1\` 包装器内容提取底层 \`.exe\` 路径。

## English

### Issue 1: Runtime detection returns empty on Windows

\`detectRuntimes()\` used \`command -v\` (bash builtin) to check installed agent CLIs. On Windows, Node.js defaults to \`cmd.exe\` which doesn't have this command, so **all runtimes reported as \`[]\`**.

**Fix:** Use \`where\` on Windows, \`command -v\` on Unix.

### Issue 2: spawn ENOENT on Windows

npm installs \`.cmd\` shims for CLIs. \`CreateProcessW\` doesn't resolve PATHEXT for bare names, so \`spawn("claude")\` fails with ENOENT.

**Fix:** New \`resolveBin()\` helper that uses \`where\` to locate the binary, then unwraps \`.cmd\`/\`.ps1\` wrappers to their underlying \`.exe\` paths.

## 测试验证 / Tested

- [x] \`detectRuntimes()\` 在 Windows 上返回 \`["claude", "codex", ...]\`
- [x] Agent 进程成功启动（Windows 11 + Node 24 实测）
- [x] 构建通过 / Build passes

## 变更文件 / Files changed

- \`src/daemon/runtimes.ts\` — 新增 \`resolveBin()\`，修复检测命令
- \`src/daemon/claudeRuntime.ts\` — \`spawn(resolveBin("claude"))\`
- \`src/daemon/codexRuntime.ts\` — \`spawn(resolveBin("codex"))\`
- \`src/daemon/copilotRuntime.ts\` — \`spawn(resolveBin("copilot"))\`
- \`src/daemon/listModels.ts\` — \`runList\` 中使用 \`resolveBin\`

---

🤖 本 PR 由 **step-3.7-flash** (Anthropic) 通过 Claude Code CLI 协助生成 / Generated with Claude Code