### PR TITLE
fix: use stable thread targets for handoff follow-ups

### DIFF
--- a/src/server/core.ts
+++ b/src/server/core.ts
@@ -671,6 +671,9 @@ export async function assignTask(
   )))[0];
   if (!cur) return null;
 
+  const sameAssignee = cur.taskAssigneeType === "agent" && cur.taskAssigneeId === assigneeId;
+  if (sameAssignee) return cur;
+
   const nextStatus = cur.taskStatus === "todo" ? "in_progress" : cur.taskStatus;
   const [upd] = await db.update(schema.messages)
     .set({

--- a/src/server/routes-agent.ts
+++ b/src/server/routes-agent.ts
@@ -49,11 +49,10 @@ async function agentChannels(agentId: string) {
 export async function addressableTarget(ch: typeof schema.channels.$inferSelect, selfAgentId: string): Promise<string> {
   // Thread channel: render as #parentChannel:shortid (or dm:@peer:shortid) so the agent can reuse it with message send --target
   if (ch.type === "thread" && ch.parentMessageId) {
-    const parent = (await db.select().from(schema.messages).where(eq(schema.messages.id, ch.parentMessageId)))[0];
-    if (parent) {
-      const pch = (await db.select().from(schema.channels).where(eq(schema.channels.id, parent.channelId)))[0];
-      if (pch) return `${await addressableTarget(pch, selfAgentId)}:${parent.id.slice(0, 8)}`;
-    }
+    // Stable across public/private/DM and across different agent viewpoints: a new assignee may only be
+    // a member of the thread itself, not of the parent DM/private channel, so caller-relative parent targets
+    // like dm:@peer:shortid do not round-trip reliably after handoff. Use thread:<parentShortId> instead.
+    return `thread:${ch.parentMessageId.slice(0, 8)}`;
   }
   if (ch.type === "dm") {
     const members = await db.select().from(schema.channelMembers).where(eq(schema.channelMembers.channelId, ch.id));

--- a/test/taskAssign.integration.ts
+++ b/test/taskAssign.integration.ts
@@ -119,6 +119,16 @@ async function main() {
   const task3 = await convertMessageToTask(serverId, msg3.id, { type: "user", id: ownerId });
   const rejected = await assignTask(serverId, task3!.id, deletedAgentId, { type: "agent", id: srcAgentId });
   check("assignTask returns null for a deleted target agent", rejected === null);
+
+  console.log("\n[6] assigning to the same assignee is idempotent (no duplicate audit)");
+  const msg4 = await createMessage({ serverId, channelId, senderType: "user", senderId: ownerId, senderName: `owner_${ts}`, content: "handoff idempotent" });
+  const task4 = await convertMessageToTask(serverId, msg4.id, { type: "user", id: ownerId });
+  const first = await assignTask(serverId, task4!.id, dstAgentId, { type: "agent", id: srcAgentId });
+  const before = await db.select().from(schema.messages).where(and(eq(schema.messages.channelId, first!.threadId!), eq(schema.messages.senderType, "system")));
+  const second = await assignTask(serverId, task4!.id, dstAgentId, { type: "agent", id: srcAgentId });
+  const after = await db.select().from(schema.messages).where(and(eq(schema.messages.channelId, first!.threadId!), eq(schema.messages.senderType, "system")));
+  check("same-assignee retry returns the existing task", second?.id === first?.id);
+  check("same-assignee retry does not append another system handoff message", after.length === before.length);
 }
 
 main()

--- a/test/taskAssignAgent.integration.ts
+++ b/test/taskAssignAgent.integration.ts
@@ -180,6 +180,19 @@ async function main() {
   await handleAgentApi(dmReadReq, dmReadRes.res, new URL(`http://localhost/agent-api/message/read?channel=${encodeURIComponent(String((dmAssign.body as any).threadTarget))}`), "GET");
   await dmReadRes.done();
   check("assignee can read thread via returned dm threadTarget", dmReadRes.status() === 200);
+
+  console.log("\n[5] assignee message-check surfaces stable thread target for DM handoff");
+  const dmCheckReq = Object.assign(Readable.from([] as Buffer[]), {
+    method: "GET",
+    url: "/agent-api/message/check",
+    headers: { authorization: `Bearer ${assigneeCfg.agentToken}`, "x-agent-id": assigneeId },
+  }) as unknown as IncomingMessage;
+  const dmCheckRes = mkRes();
+  await handleAgentApi(dmCheckReq, dmCheckRes.res, new URL("http://localhost/agent-api/message/check"), "GET");
+  await dmCheckRes.done();
+  const dmCheckBody = dmCheckRes.body();
+  const texts = Array.isArray((dmCheckBody as any).messages) ? (dmCheckBody as any).messages.map((m: any) => String(m.text || "")) : [];
+  check("message check exposes thread:shortid instead of actor-relative dm target", texts.some((txt: string) => txt.includes(`[target=thread:${dmTask!.id.slice(0, 8)}`)));
 }
 
 main()


### PR DESCRIPTION
## Why

`#147` was merged before the final follow-up fix commit (`a8a601d`) landed on the feature branch.
This PR contains only that missed follow-up.

## What it fixes

- uses stable `thread:<parentShortId>` targets in the agent-facing thread loop
- fixes DM/private handoff follow-up targets in the real assignee workflow
- makes same-assignee handoff retries idempotent
- adds regression coverage for:
  - DM/private returned thread target readability
  - DM assignee `message check` surfacing stable `thread:` target
  - same-assignee no-op retry not duplicating audit messages

## Verification

- `npx tsx test/taskAssign.integration.ts`
- `npx tsx test/taskAssignAgent.integration.ts`
- `npm run typecheck`

All passed locally.
