### PR TITLE
fix(server): 一 machine 一 daemon ws（修 agent 双回复/双投递）

### DIFF
--- a/scripts/dev-e2e-down.sh
+++ b/scripts/dev-e2e-down.sh
@@ -7,9 +7,12 @@ HOME_DIR=$(grep -E "^OPEN_TAG_HOME=" .env | head -1 | cut -d= -f2- | sed "s|^\$H
 RUN="${HOME_DIR:-$HOME/.open-tag}"
 for svc in server daemon; do
   f="$RUN/dev-e2e-$svc.pid"
+  # Kill the whole process tree, not just the recorded npm-exec parent: `kill $pid` alone orphans the
+  # tsx → node children (they keep running, holding the WS open → ghost daemons that cause double-delivery).
+  pkill -f "$PWD/src/$svc/index.ts" 2>/dev/null || true
   if [ -f "$f" ]; then
     pid=$(cat "$f")
-    if kill "$pid" 2>/dev/null; then echo "  stopped $svc ($pid)"; else echo "  $svc not running"; fi
+    kill "$pid" 2>/dev/null && echo "  stopped $svc ($pid)" || echo "  $svc not running"
     rm -f "$f"
   fi
 done

--- a/src/server/daemonHub.ts
+++ b/src/server/daemonHub.ts
@@ -10,7 +10,17 @@ const machineConns = new Map<string, WebSocket>(); // machineId → ws, so a req
 
 export function registerDaemon(ws: WebSocket, serverId: string): void { daemons.set(ws, serverId); }
 export function unregisterDaemon(ws: WebSocket): void { daemons.delete(ws); }
-export function registerMachineConn(machineId: string, ws: WebSocket): void { machineConns.set(machineId, ws); }
+export function registerMachineConn(machineId: string, ws: WebSocket): void {
+  const prev = machineConns.get(machineId);
+  if (prev && prev !== ws) {
+    // Same machine, new connection (reconnect / orphan / accidental 2nd daemon): evict the previous ws
+    // from the broadcast map and close it. Without this, broadcastToDaemons delivers agent:start / agent:deliver
+    // to BOTH ws → each daemon spawns its own agent instance → double replies + double token spend.
+    daemons.delete(prev);
+    try { if (prev.readyState === 1) prev.close(); } catch { /* */ }
+  }
+  machineConns.set(machineId, ws);
+}
 export function unregisterMachineConn(ws: WebSocket): void { for (const [mid, w] of machineConns) if (w === ws) machineConns.delete(mid); }
 export function isCurrentMachineConn(machineId: string, ws: WebSocket): boolean { return machineConns.get(machineId) === ws; }
 export function daemonCount(serverId: string): number {

--- a/test/daemonHub.unit.test.ts
+++ b/test/daemonHub.unit.test.ts
@@ -1,0 +1,49 @@
+// Unit test for daemonHub's machine-connection dedup invariant: one machine == at most one daemon ws in
+// the broadcast map. Without this, a reconnect/orphan/accidental 2nd daemon on the same machine makes
+// broadcastToDaemons deliver agent:start/agent:deliver to BOTH ws → each daemon spawns its own agent
+// instance → double replies + double token spend (root-caused against the cctest incident, 2026-07-02).
+// Run: npx tsx --test test/daemonHub.unit.test.ts
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { registerDaemon, unregisterDaemon, registerMachineConn, unregisterMachineConn, broadcastToDaemons } from "../src/server/daemonHub.js";
+
+// Minimal fake ws: readyState=OPEN(1), counts sends + close.
+function fakeWs(): any {
+  return { readyState: 1, sends: 0, closed: false, send() { this.sends++; }, close() { this.closed = true; } };
+}
+
+test("same machine: 2nd ws evicts 1st from broadcast + closes it (no double delivery)", () => {
+  const sid = "s-dedup-" + Math.random().toString(36).slice(2);
+  const ws1 = fakeWs(), ws2 = fakeWs();
+  registerDaemon(ws1, sid);
+  registerDaemon(ws2, sid);            // both in the daemons map now
+  registerMachineConn("m1", ws1);
+  registerMachineConn("m1", ws2);      // ws2 takes over → ws1 must be evicted + closed
+  broadcastToDaemons(sid, { type: "agent:deliver" });
+  assert.equal(ws2.sends, 1, "new ws receives the broadcast exactly once");
+  assert.equal(ws1.sends, 0, "evicted ws receives nothing");
+  assert.equal(ws1.closed, true, "evicted ws is closed so its daemon tears down");
+  unregisterDaemon(ws2); unregisterMachineConn(ws2);
+});
+
+test("single ws: broadcast delivered once (regression guard)", () => {
+  const sid = "s-single-" + Math.random().toString(36).slice(2);
+  const ws = fakeWs();
+  registerDaemon(ws, sid);
+  registerMachineConn("m1", ws);
+  broadcastToDaemons(sid, { type: "agent:deliver" });
+  assert.equal(ws.sends, 1);
+  unregisterDaemon(ws); unregisterMachineConn(ws);
+});
+
+test("multi-tenant: broadcast does not cross servers", () => {
+  const a = "s-A-" + Math.random().toString(36).slice(2), b = "s-B-" + Math.random().toString(36).slice(2);
+  const wsA = fakeWs(), wsB = fakeWs();
+  registerDaemon(wsA, a); registerDaemon(wsB, b);
+  registerMachineConn("mA", wsA); registerMachineConn("mB", wsB);
+  broadcastToDaemons(a, { type: "x" });
+  assert.equal(wsA.sends, 1);
+  assert.equal(wsB.sends, 0, "server B's daemon must not receive server A's broadcast");
+  unregisterDaemon(wsA); unregisterMachineConn(wsA);
+  unregisterDaemon(wsB); unregisterMachineConn(wsB);
+});


### PR DESCRIPTION
## Summary
强制 server 不变量：**一台 machine 至多一个 daemon ws**。`broadcastToDaemons` 原来遍历 ws-keyed 的 `daemons` map，同 machine 一旦出现两个 ws（重连残留 / 孤儿 / 误起两个 daemon），`agent:start` 和 `agent:deliver` 各发两份 → 每个 daemon 各 spawn 一个 claude 实例 → 每条消息双回复 + 双 token。这是 cctest 双回复事件的根因。

## 根因（daemonHub.ts）
- `daemons = Map<ws, serverId>`（广播用，**不去重**）
- `machineConns = Map<machineId, ws>`（定向 RPC 用，**已去重**）
- `broadcastToDaemons` 遍历 `daemons`（ws-map），没用 machine 去重的 `machineConns`

## 修复
`registerMachineConn` 在覆盖旧 ws 时，顺手把它从 `daemons` 删掉 + close（~5 行）。

## 边界（诚实交代）
- **prod 重连残留**（单 daemon 进程，新 ws 替换半开旧 ws）：干净接管，无副作用。
- **两 daemon 进程**（dev 孤儿 / 误配置）：会 flap（machine ready/disconnect 反复）——这是配置错误**显性报错**，不是静默双回复。配合 `dev-e2e-down` 杀整棵进程树避免 dev 孤儿。

## 改动
| 文件 | 改动 |
|---|---|
| `src/server/daemonHub.ts` | `registerMachineConn` 踢出 + close 旧 ws |
| `test/daemonHub.unit.test.ts` | 3 case：双 ws 去重 / 单 ws 回归 / 多租户隔离 |
| `scripts/dev-e2e-down.sh` | `pkill -f` 杀 tsx→node 整树（原 `kill $pid` 漏杀 npm-exec 子进程 → 孤儿 daemon，正是本 bug 的触发源之一） |

## 证据
- **单测 3/3**（先红后绿：旧码 `evicted ws receives nothing: 1 !== 0` 复现 bug，修复后绿）
- **typecheck** 0 错
- **端到端**（worktree 起同 machine 两个 daemon）：server log 显示 B ready → A `daemon disconnected`（13:39:11.759→.768），修复机制生效；flap 显性（两进程互相踢，区别于修复前的静默双投递）

## 未验证
- prod 线上真实重连残留（单进程新 ws）——逻辑上无 flap，但没在线上复现
- flapping 的进一步处理（如 daemon 端收到"被取代"信号后退避/退出）——后续 issue，本 PR 不含

## 不用发 daemon 包
纯 server 端（`daemonHub.ts`）+ dev 脚本，merged → `railway up` 即生效。