### PR TITLE
fix(web): show retry state when chat load fails

### DIFF
--- a/test/chatInitialLoadError.unit.test.ts
+++ b/test/chatInitialLoadError.unit.test.ts
@@ -15,7 +15,15 @@ test("initial message load failure exits the skeleton and shows a retryable erro
   assert.match(chatSrc, /loaded && loadError/);
   assert.match(chatSrc, /onClick=\{loadCurrentMessages\}/);
   assert.match(chatSrc, /t\("chat\.loadFailedTitle"\)/);
+  assert.match(chatSrc, /t\("chat\.loadFailedBody"\)/);
   assert.match(chatSrc, /t\("chat\.retryLoad"\)/);
+});
+
+test("initial message load drops stale async results after switching channels", () => {
+  assert.match(chatSrc, /const chId = cur\.id/);
+  assert.match(chatSrc, /if \(curIdRef\.current !== chId\) return;[\s\S]*setMsgs\(ms\)/);
+  assert.match(chatSrc, /catch\s*(?:\([^)]*\))?\s*\{[\s\S]*if \(curIdRef\.current !== chId\) return;[\s\S]*setLoadError\(true\)/);
+  assert.match(chatSrc, /finally\s*\{[\s\S]*if \(curIdRef\.current === chId\) setLoaded\(true\)/);
 });
 
 test("chat load failure copy is localized", () => {

--- a/test/chatInitialLoadError.unit.test.ts
+++ b/test/chatInitialLoadError.unit.test.ts
@@ -1,0 +1,29 @@
+// Unit regression for the chat message initial-load failure state.
+// Run: npx tsx --test --test-force-exit test/chatInitialLoadError.unit.test.ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const chatSrc = fs.readFileSync(new URL("../web/src/views/Chat.tsx", import.meta.url), "utf8");
+const en = JSON.parse(fs.readFileSync(new URL("../web/src/locales/en.json", import.meta.url), "utf8"));
+const zh = JSON.parse(fs.readFileSync(new URL("../web/src/locales/zh.json", import.meta.url), "utf8"));
+
+test("initial message load failure exits the skeleton and shows a retryable error state", () => {
+  assert.match(chatSrc, /const \[loadError,\s*setLoadError\] = useState/);
+  assert.match(chatSrc, /catch\s*(?:\([^)]*\))?\s*\{[\s\S]*setLoadError\(/);
+  assert.match(chatSrc, /finally\s*\{[\s\S]*setLoaded\(true\)/);
+  assert.match(chatSrc, /loaded && loadError/);
+  assert.match(chatSrc, /onClick=\{loadCurrentMessages\}/);
+  assert.match(chatSrc, /t\("chat\.loadFailedTitle"\)/);
+  assert.match(chatSrc, /t\("chat\.retryLoad"\)/);
+});
+
+test("chat load failure copy is localized", () => {
+  assert.equal(en.chat.loadFailedTitle, "Could not load this conversation");
+  assert.equal(en.chat.loadFailedBody, "OpenTag could not reach the server. Check that the control plane is running, then retry.");
+  assert.equal(en.chat.retryLoad, "Retry");
+
+  assert.equal(zh.chat.loadFailedTitle, "无法加载此对话");
+  assert.equal(zh.chat.loadFailedBody, "OpenTag 暂时连不上服务端。确认 control plane 正在运行后重试。");
+  assert.equal(zh.chat.retryLoad, "重试");
+});

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -352,6 +352,9 @@
     "join": "Join",
     "noFiles": "No files in this channel yet. Click the paperclip in the chat composer to upload (files are sent with messages and visible to all members).",
     "channelEmpty": "No messages yet",
+    "loadFailedTitle": "Could not load this conversation",
+    "loadFailedBody": "OpenTag could not reach the server. Check that the control plane is running, then retry.",
+    "retryLoad": "Retry",
     "jumpToMessage": "Jump to original message",
     "download": "Download",
     "asTask": "As Task"

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -352,6 +352,9 @@
     "join": "加入",
     "noFiles": "本频道暂无文件。在聊天框点回形针上传(会随消息发出,团队都能看到/下载)。",
     "channelEmpty": "还没有消息",
+    "loadFailedTitle": "无法加载此对话",
+    "loadFailedBody": "OpenTag 暂时连不上服务端。确认 control plane 正在运行后重试。",
+    "retryLoad": "重试",
     "jumpToMessage": "跳到原消息",
     "download": "下载",
     "asTask": "作为任务"

--- a/web/src/views/Chat.tsx
+++ b/web/src/views/Chat.tsx
@@ -117,6 +117,7 @@ export function Chat() {
   const [ctxMenu, setCtxMenu] = useState<{ m: Msg; x: number; y: number } | null>(null); // right-clicking a message opens the context action menu
   const [msgs, setMsgs] = useState<Msg[]>([]);
   const [loaded, setLoaded] = useState(false); // first fetch for the current channel done — gates the empty-channel state so it never flashes mid-load
+  const [loadError, setLoadError] = useState(false); // first fetch failed — exits the skeleton into a retryable error state
   const [sub, setSub] = useState("");
   const [showMembers, setShowMembers] = useState(false);
   const [thread, setThread] = useState<{ channelId: string; parent: Msg } | null>(null); // currently open thread panel
@@ -159,15 +160,39 @@ export function Chat() {
     setShownChannelId(cur?.id);
     setMsgs([]);
     setLoaded(false);
+    setLoadError(false);
     setHasMore(false);
   }
 
   useEffect(() => { if (!channelId && cur) nav(`/s/${slug}/channel/${cur.id}`, { replace: true }); }, [channelId, cur, slug, nav]);
-  useEffect(() => { if (!cur) return; setThread(null); setProfile(null); loadingOlderRef.current = false; prependRestoreRef.current = null; subscribeChannel(cur.id); (async () => { // switching channels closes any open thread + profile overlay from the previous channel (loaded/msgs/hasMore reset happens synchronously in the render-phase guard above) (the live trace itself persists — accumulated in the store, see store.tsx); join the room while viewing so message:new arrives live (covers public non-member channels + channels relevant after connect)
-    const d = await api("GET", `/api/messages/channel/${cur.id}?limit=${PAGE_SIZE}`); const ms: Msg[] = d.messages || []; setMsgs(ms); setLoaded(true); setHasMore(!!d.hasMore); markRead(cur.id);
-    const ids = ms.map((m) => m.id);
-    if (ids.length) { try { setThreadMeta(await api("GET", `/api/channels/${cur.id}/threads?parentMessageIds=${ids.join(",")}`) || {}); } catch { setThreadMeta({}); } } else setThreadMeta({});
-  })(); }, [cur?.id]);
+  const loadCurrentMessages = async () => {
+    if (!cur) return;
+    const chId = cur.id;
+    setLoaded(false);
+    setLoadError(false);
+    try {
+      const d = await api("GET", `/api/messages/channel/${chId}?limit=${PAGE_SIZE}`);
+      if (curIdRef.current !== chId) return;
+      const ms: Msg[] = d.messages || [];
+      setMsgs(ms);
+      setHasMore(!!d.hasMore);
+      markRead(chId);
+      const ids = ms.map((m) => m.id);
+      if (ids.length) {
+        try { setThreadMeta(await api("GET", `/api/channels/${chId}/threads?parentMessageIds=${ids.join(",")}`) || {}); }
+        catch { setThreadMeta({}); }
+      } else setThreadMeta({});
+    } catch {
+      if (curIdRef.current !== chId) return;
+      setMsgs([]);
+      setThreadMeta({});
+      setHasMore(false);
+      setLoadError(true);
+    } finally {
+      if (curIdRef.current === chId) setLoaded(true);
+    }
+  };
+  useEffect(() => { if (!cur) return; setThread(null); setProfile(null); loadingOlderRef.current = false; prependRestoreRef.current = null; subscribeChannel(cur.id); void loadCurrentMessages(); }, [cur?.id]);
   // Surface unread that lives in this channel's threads (folded away, invisible in the main timeline → "滑不到").
   // Re-runs when the channel's badge changes: entry, a new thread reply bumping it, or opening a thread clearing it.
   useEffect(() => {
@@ -310,8 +335,9 @@ export function Chat() {
             )}
             <div key={cur?.id} className="scroll ch-view-enter" ref={scrollRef} onScroll={onScroll}>
               {!loaded && <ChatSkeleton />}
-              {loaded && !msgs.length && <PaneEmpty icon={<MessageCircle size={30} />} title={t("chat.channelEmpty")} />}
-              {msgs.map((m) => {
+              {loaded && loadError && <PaneEmpty icon={<MessageCircle size={30} />} title={t("chat.loadFailedTitle")} sub={<><span>{t("chat.loadFailedBody")}</span><button className="joinbtn" onClick={loadCurrentMessages}>{t("chat.retryLoad")}</button></>} />}
+              {loaded && !loadError && !msgs.length && <PaneEmpty icon={<MessageCircle size={30} />} title={t("chat.channelEmpty")} />}
+              {!loadError && msgs.map((m) => {
                 const ag = m.senderType === "agent" && m.senderId ? agents.find((a) => a.id === m.senderId) : undefined; // used for role description and avatar status dot
                 const tm = threadMeta[m.id];
                 const isMember = m.senderType !== "agent" && m.senderType !== "system"; // human/user senders get a "member" badge


### PR DESCRIPTION
## Summary
- replace the chat message initial-load infinite skeleton with a retryable error state when the API request fails
- localize the new load-failed title/body/retry copy in English and Chinese
- add regression coverage for the retry state, stale channel async guard, and localized copy

## Root Cause
If the initial `/api/messages/channel/:id` request rejected, `loaded` was never set to true. The chat pane stayed on `ChatSkeleton` forever, even though the user could still interact with the composer and sidebar.

## Validation
- `TMPDIR=/tmp /Applications/Codex.app/Contents/Resources/cua_node/bin/node ../open-tag/node_modules/tsx/dist/cli.mjs --test --test-force-exit test/chatInitialLoadError.unit.test.ts test/skeletonLoading.unit.test.ts`
- `npm run typecheck`
- `npm run web:build`
- reviewer local validation: full node:test, daemon package build, and production audit passed

## Notes
This is intentionally narrow: it only changes the chat initial-load failure UI and source-level regression coverage.