### PR TITLE
fix(web): chat skeleton and real messages render stacked during load

### DIFF
--- a/test/chatInitialLoadError.unit.test.ts
+++ b/test/chatInitialLoadError.unit.test.ts
@@ -26,6 +26,15 @@ test("initial message load drops stale async results after switching channels", 
   assert.match(chatSrc, /finally\s*\{[\s\S]*if \(curIdRef\.current === chId\) setLoaded\(true\)/);
 });
 
+test("message list render is mutually exclusive with the loading skeleton", () => {
+  // Regression: loadCurrentMessages calls setMsgs(ms) before an awaited threadMeta fetch, and only
+  // sets loaded=true in the finally block after that fetch resolves. If the message-list render isn't
+  // gated on `loaded` too, that in-between render paints the skeleton (`!loaded`) and the real message
+  // list (msgs already populated) stacked on top of each other. Reproduced live: a delayed threads
+  // endpoint made the skeleton and real messages render together in the same scroll container.
+  assert.match(chatSrc, /\{loaded && !loadError && msgs\.map\(/);
+});
+
 test("chat load failure copy is localized", () => {
   assert.equal(en.chat.loadFailedTitle, "Could not load this conversation");
   assert.equal(en.chat.loadFailedBody, "OpenTag could not reach the server. Check that the control plane is running, then retry.");

--- a/web/src/views/Chat.tsx
+++ b/web/src/views/Chat.tsx
@@ -337,7 +337,7 @@ export function Chat() {
               {!loaded && <ChatSkeleton />}
               {loaded && loadError && <PaneEmpty icon={<MessageCircle size={30} />} title={t("chat.loadFailedTitle")} sub={<><span>{t("chat.loadFailedBody")}</span><button className="joinbtn" onClick={loadCurrentMessages}>{t("chat.retryLoad")}</button></>} />}
               {loaded && !loadError && !msgs.length && <PaneEmpty icon={<MessageCircle size={30} />} title={t("chat.channelEmpty")} />}
-              {!loadError && msgs.map((m) => {
+              {loaded && !loadError && msgs.map((m) => {
                 const ag = m.senderType === "agent" && m.senderId ? agents.find((a) => a.id === m.senderId) : undefined; // used for role description and avatar status dot
                 const tm = threadMeta[m.id];
                 const isMember = m.senderType !== "agent" && m.senderType !== "system"; // human/user senders get a "member" badge


### PR DESCRIPTION
## Summary
- `web/src/views/Chat.tsx:340` gated the message list render on `!loadError` only, not `loaded`. `loadCurrentMessages` calls `setMsgs(ms)` before an *awaited* `threadMeta` fetch, and only flips `loaded=true` in the `finally` block that runs after that second fetch resolves — React flushes the intermediate render, so on any channel/DM with history the skeleton (`!loaded`) and the real message list briefly render stacked on top of each other.
- Regression introduced in #161 (`fix(web): show retry state when chat load fails`), which moved `setLoaded(true)` into a `finally` block placed after the `threadMeta` await, without re-gating the message-list render to match.
- Fix: `{!loadError && msgs.map(...)}` → `{loaded && !loadError && msgs.map(...)}`, mirroring the other three render branches in that block so they stay mutually exclusive.

## Test plan
- [x] Reproduced live in an isolated worktree stack: added a temporary artificial delay to `GET /api/channels/:id/threads`, reloaded a channel with existing messages — confirmed the skeleton placeholders and real messages rendered stacked together (matching the reported screenshot), on the pre-fix code.
- [x] Applied the one-line fix, repeated the same repro — confirmed the skeleton and message list no longer co-render; the channel transitions cleanly skeleton → messages. Removed the temporary delay before committing.
- [x] Added a regression unit test (`test/chatInitialLoadError.unit.test.ts`) asserting the render is gated on `loaded && !loadError`.
- [x] `npm run typecheck` (root + web) — clean.
- [x] `npx tsx --test --test-force-exit test/*.unit.test.ts` — 221/221 pass.
- [x] `npm run web:build` — clean.

Not run: no doc-sync needed per AGENTS.md's table (pure bug fix in existing render logic, no schema/route/module-boundary/feature change).