### PR TITLE
fix(chat): fade top of message scroll under unread-threads bar

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -623,6 +623,10 @@ aside.traj-col h2{position:relative;font-size:12px;font-weight:600;letter-spacin
 .unread-threads-bar svg{color:var(--amber);flex:none}
 .unread-threads-bar .utb-label{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .unread-threads-bar .utb-cta{color:var(--amber);font-weight:700;flex:none}
+/* When the bar above is showing, a message scrolled up to the very top edge of .scroll gets its
+   avatar/name/timestamp clipped by the container boundary, leaving bare body text flush against the
+   bar's solid background — reads as one broken box. Fade the top ~32px instead of hard-clipping it. */
+.scroll-fade-top{-webkit-mask-image:linear-gradient(to bottom, transparent, black 32px);mask-image:linear-gradient(to bottom, transparent, black 32px)}
 /* action card (B-mode proposal card). Editorial style: off-white surface + hairline + pill CTA */
 .action-card{margin-top:4px;max-width:440px;background:var(--surface);border:1px solid var(--hair-strong);border-radius:12px;padding:12px 14px}
 .action-card .ac-title{font-size:15px;font-weight:600;color:var(--ink);letter-spacing:.1px}

--- a/web/src/views/Chat.tsx
+++ b/web/src/views/Chat.tsx
@@ -410,7 +410,7 @@ export function Chat() {
                 <span className="utb-cta">{t("chat.viewUnreadThread")}</span>
               </button>
             )}
-            <div key={cur?.id} className="scroll ch-view-enter" ref={scrollRef} onScroll={onScroll}>
+            <div key={cur?.id} className={"scroll ch-view-enter" + (chatTab === "chat" && unreadThreads.length > 0 ? " scroll-fade-top" : "")} ref={scrollRef} onScroll={onScroll}>
               {!loaded && <ChatSkeleton />}
               {loaded && loadError && <PaneEmpty icon={<MessageCircle size={30} />} title={t("chat.loadFailedTitle")} sub={<><span>{t("chat.loadFailedBody")}</span><button className="joinbtn" onClick={loadCurrentMessages}>{t("chat.retryLoad")}</button></>} />}
               {loaded && !loadError && !msgs.length && <PaneEmpty icon={<MessageCircle size={30} />} title={t("chat.channelEmpty")} />}


### PR DESCRIPTION
## Bug

Reported from a live screenshot: the "N 条未读话题回复" bar (added in #132) looked "smushed together" with the message right below it — no avatar, no username, just body text glued to the bar.

## Root cause

`.unread-threads-bar` (`Chat.tsx`) is a non-scrolling sibling of the independently-scrollable `.scroll` message list. `.scroll` has no top fade/mask anywhere in the stylesheet — content that scrolls past the container's top edge gets hard-clipped. Channels are pinned to the bottom by default, so whenever total message height exceeds the viewport, whatever message happens to intersect the top edge has its `.msg-head` (avatar + name + timestamp) clipped off entirely, leaving only its bare `mbody` text visible, flush against whatever sits above `.scroll` — normally invisible (white-on-white), but glaringly obvious once #132 put a solid amber bar there.

Confirmed via `git log -S"unread-threads-bar"` → introduced in `ed2a607` / PR #132 (`feature/unread-resurrection`, merged 2026-06-27). That PR's own verification notes flagged the bar UI as untested by automation — this exact scroll-position case wasn't covered.

## Fix

Add a `mask-image` top fade (32px) to `.scroll`, applied only via a `scroll-fade-top` class when the unread-threads bar is actually showing (`chatTab === "chat" && unreadThreads.length > 0`) — a clipped message now dissolves into the background instead of hard-cutting. Scoped narrowly so channels without the bar keep their existing (unaffected) scroll behavior.

## Evidence

- `npm run typecheck` (root + web): clean.
- `npm run build` (web): clean, confirmed `.scroll-fade-top` rule present in the shipped CSS bundle.
- **Live mechanism verification (chrome-devtools, real browser):** built a faithful repro using the actual shipped CSS classes (`.unread-threads-bar`, `.msg`, `.scroll`, etc.), forced the exact clipped-scroll state, and screenshotted before/after applying `scroll-fade-top`. Before: hard-clipped avatar sliver + truncated username fragment sit flush under the bar. After: the same region dissolves smoothly — avatar fades to nothing, truncated header text vanishes, body text starts faint and ramps to full opacity below the 32px band. Confirms the CSS mechanism actually renders as intended, not just correct on paper.

## Not verified (fail-loud)

- Not exercised against a real authenticated session on the running local "prod" instance (`:7788`) — that instance has `ALLOW_DEV_LOGIN` off (real prod data), so verification used an isolated repro built from the same shipped CSS instead of logging into production. No behavioral difference expected (same CSS, same class, same markup shape) but worth a quick look in a real channel by whoever reviews.
- No automated test added — this is a pure CSS visual fix; no test infra exists for `.scroll` clipping behavior in this repo.