### PR TITLE
fix(web): toast on channel-create failure instead of silently closing modal

### DIFF
--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -479,7 +479,9 @@
     "humanSection": "Members",
     "noMembers": "No members to add",
     "cancelBtn": "Cancel",
-    "createBtn": "Create"
+    "createBtn": "Create",
+    "createChannelDup": "A channel with this name already exists",
+    "createChannelFailed": "Failed to create channel"
   },
   "common": {
     "agents": "Agents",

--- a/web/src/locales/zh.json
+++ b/web/src/locales/zh.json
@@ -479,7 +479,9 @@
     "humanSection": "成员",
     "noMembers": "无可选成员",
     "cancelBtn": "取消",
-    "createBtn": "创建"
+    "createBtn": "创建",
+    "createChannelDup": "同名频道已存在",
+    "createChannelFailed": "创建频道失败"
   },
   "common": {
     "agents": "Agents",

--- a/web/src/store.tsx
+++ b/web/src/store.tsx
@@ -37,7 +37,7 @@ interface Store {
   reload: () => Promise<void>;
   onEvent: (cb: (e: Ev) => void) => () => void;
   subscribeChannel: (id: string) => void;                         // join the channel/thread's realtime room while it is being viewed (idempotent; re-emitted on reconnect)
-  createChannel: (opts: { name: string; description?: string; visibility?: string; agentIds?: string[]; userIds?: string[] }) => Promise<{ id: string } | null>;
+  createChannel: (opts: { name: string; description?: string; visibility?: string; agentIds?: string[]; userIds?: string[] }) => Promise<{ id?: string; error?: string } | null>;
   markActionExecuted: (messageId: string, result?: { kind: string; id: string; name: string }) => Promise<void>; // mark action card as executed after submission
   createTasks: (channelId: string, titles: string[]) => Promise<any[]>;
   openDM: (memberType: string, memberId: string) => Promise<string | null>;
@@ -118,7 +118,9 @@ export function StoreProvider({ children }: { children: ReactNode }) {
   // channel became relevant (public non-member, thread, or appeared after connect). Tracked so a reconnect re-joins. Idempotent.
   const subscribeChannel = (id: string) => { if (!id) return; subscribedRef.current.add(id); sockRef.current?.emit("join:channel", id); };
 
-  const createChannel = async (opts: { name: string; description?: string; visibility?: string; agentIds?: string[]; userIds?: string[] }) => { const r = await api("POST", "/api/channels", { name: opts.name, description: opts.description, visibility: opts.visibility, agentIds: opts.agentIds ?? [], userIds: opts.userIds ?? [] }); if (r?.id) { await reload(); sockRef.current?.emit("join:channel", r.id); } return r?.id ? r : null; };
+  // Returns the raw response (incl. `error` on failure, e.g. 409 "channel name exists") instead of collapsing
+  // it to null — callers need `error` to surface a toast instead of silently closing the create-channel modal.
+  const createChannel = async (opts: { name: string; description?: string; visibility?: string; agentIds?: string[]; userIds?: string[] }) => { const r = await api("POST", "/api/channels", { name: opts.name, description: opts.description, visibility: opts.visibility, agentIds: opts.agentIds ?? [], userIds: opts.userIds ?? [] }); if (r?.id) { await reload(); sockRef.current?.emit("join:channel", r.id); } return r; };
   // Create workspace → optimistically add it to the server list (POST returns role+capabilities so no re-fetch needed) and
   // return the new slug. The caller navigates client-side to /s/<slug>/channel; the URL drives activation (see main.tsx),
   // so there is no full-page reload — the workspace skeleton shows while the new workspace's data loads.

--- a/web/src/views/Chat.tsx
+++ b/web/src/views/Chat.tsx
@@ -17,10 +17,11 @@ import { TaskBoard, ynOptions, ST_LABEL } from "../TaskBoard.tsx";
 import { PaneEmpty } from "../PaneEmpty.tsx";
 import { ChatSkeleton } from "./Skeleton.tsx";
 import { AgentProfile, HumanProfile, CreateAgentModal } from "./Members.tsx";
-import { ChatSidebar, CreateChannelModal } from "./ChatSidebar.tsx";
+import { ChatSidebar, CreateChannelModal, channelCreateErrorMsg } from "./ChatSidebar.tsx";
 import { ConnectComputerWizard } from "./ConnectComputerWizard.tsx";
 import { Composer } from "./Composer.tsx";
 import { useConfirm, useEscClose } from "../ConfirmModal.tsx";
+import { useToast } from "../toast.tsx";
 
 const fmtSize = (n?: number) => (!n ? "" : n < 1024 ? n + " B" : n < 1048576 ? (n / 1024).toFixed(1) + " KB" : (n / 1048576).toFixed(1) + " MB");
 const isImage = (m?: string) => !!m && m.startsWith("image/");
@@ -104,6 +105,7 @@ function Reactions({ m, mine, onReact }: { m: Msg; mine: string; onReact: (emoji
 function ActionCardMsg({ m }: { m: Msg }) {
   const { t } = useTranslation();
   const { createChannel, markActionExecuted, slug, agents, attachmentUrl } = useStore();
+  const toast = useToast();
   const nav = useNavigate();
   const [open, setOpen] = useState(false);
   const meta = m.actionMetadata!;
@@ -130,7 +132,11 @@ function ActionCardMsg({ m }: { m: Msg }) {
         <CreateChannelModal
           prefill={{ name: a.name, description: a.description ?? "", visibility: a.visibility, agentIds: a.initialAgents ?? [], userIds: a.initialHumans ?? [] }}
           submitLabel={t("chat.createChannel")} onClose={() => setOpen(false)}
-          onCreate={async (opts) => { const r = await createChannel(opts); setOpen(false); if (r?.id) { await markActionExecuted(m.id, { kind: "channel", id: r.id, name: opts.name }); nav(`/s/${slug}/channel/${r.id}`); } }}
+          onCreate={async (opts) => {
+            const r = await createChannel(opts);
+            if (r?.id) { setOpen(false); await markActionExecuted(m.id, { kind: "channel", id: r.id, name: opts.name }); nav(`/s/${slug}/channel/${r.id}`); }
+            else toast.error(channelCreateErrorMsg(t, r?.error)); // keep the modal open so the user can fix the name and retry
+          }}
         />
       )}
       {open && !isChan && (

--- a/web/src/views/ChatSidebar.tsx
+++ b/web/src/views/ChatSidebar.tsx
@@ -6,12 +6,20 @@ import { useStore } from "../store.tsx";
 import { Avatar, resolveAvatar } from "../Avatar.tsx";
 import { useEscClose } from "../ConfirmModal.tsx";
 import { LiveAgentBar } from "./LiveAgentBar.tsx";
+import { useToast } from "../toast.tsx";
+
+// Maps the create-channel API's `error` string (e.g. 409 "channel name exists") to a localized toast message.
+// Shared by ChatSidebar's own create-channel button and Chat.tsx's action-card create-channel flow.
+export function channelCreateErrorMsg(t: (key: string) => string, error?: string): string {
+  return error === "channel name exists" ? t("sidebar.createChannelDup") : t("sidebar.createChannelFailed");
+}
 
 // Shared chat sidebar (Saved/Channels/DMs share the same sidebar; persists unchanged when switching between the channel view and the Saved view).
 // Both the Chat view and the Saved view (misc.tsx) render this component so the channel list stays visible when navigating to Saved.
 export function ChatSidebar() {
   const { t } = useTranslation();
   const { api, serverId, channels, dms, unread, agents, visibleAgents, slug, savedIds, capabilities, createChannel, openDM, joinChannel, attachmentUrl } = useStore();
+  const toast = useToast();
   const avFor = (u?: string | null) => resolveAvatar(u, attachmentUrl);
   const { channelId } = useParams();
   const { pathname } = useLocation();
@@ -32,7 +40,11 @@ export function ChatSidebar() {
     try { await api("PUT", `/api/servers/${serverId}/sidebar-order`, { pinnedChannelIds: next }); } catch { /* rollback deferred to next load */ }
   };
   useEffect(() => { if (!serverId) return; api("GET", `/api/servers/${serverId}/sidebar-order`).then((p) => setPinned(p?.pinnedChannelIds || [])).catch(() => {}); }, [serverId]);
-  const doCreate = async (opts: { name: string; description?: string; visibility?: string; agentIds?: string[]; userIds?: string[] }) => { const r = await createChannel(opts); setMkChan(false); if (r?.id) nav(`/s/${slug}/channel/${r.id}`); };
+  const doCreate = async (opts: { name: string; description?: string; visibility?: string; agentIds?: string[]; userIds?: string[] }) => {
+    const r = await createChannel(opts);
+    if (r?.id) { setMkChan(false); nav(`/s/${slug}/channel/${r.id}`); }
+    else toast.error(channelCreateErrorMsg(t, r?.error)); // keep the modal open so the user can fix the name and retry
+  };
   const doDM = async (agentId: string) => { const id = await openDM("agent", agentId); setDmPick(false); if (id) nav(`/s/${slug}/channel/${id}`); };
 
   const chanRow = (c: any) => (


### PR DESCRIPTION
## Summary
- `createChannel()` in `store.tsx` collapsed any non-2xx `/api/channels` response (e.g. 409 `channel name exists`) to `null`, discarding the `error` string.
- Both call sites (`ChatSidebar.tsx`'s create-channel button, `Chat.tsx`'s action-card create-channel flow) closed the modal unconditionally and only acted further on success — so a duplicate-name (or any) creation failure looked identical to success: modal closes, nothing happens, no feedback.
- `createChannel` now returns the raw response; both call sites only close the modal + navigate on success, and `toast.error(...)` the failure otherwise (keeping the modal open so the name can be fixed and retried). Added `sidebar.createChannelDup` / `sidebar.createChannelFailed` i18n keys (en/zh).

## Test plan
- [x] `npm run typecheck` (root + web) — clean
- [x] `npx tsx --test --test-force-exit test/*.unit.test.ts src/daemon/*.test.ts` — 316/316 pass (one `authFailFast` failure on the first run was confirmed environment-flake/order-dependent, not caused by this change — reran clean and in an isolated env)
- [x] Live browser verification (isolated worktree stack, dev-login): created channel `dup-toast-test`, then tried to create it again — modal stayed open, toast showed "A channel with this name already exists", sidebar already listed the first successfully-created channel. Screenshot confirms the fix.