### PR TITLE
Fade agent status badge on message hover to avoid toolbar collision

### DIFF
--- a/test/messageHeaderLayout.unit.test.ts
+++ b/test/messageHeaderLayout.unit.test.ts
@@ -190,6 +190,13 @@ test("message toolbar stays inside the message border and exposes save/copy/more
   assert.match(ruleBody(".msg-toolbar button.on"), /color\s*:\s*var\(--ink\)/, "saved toolbar button should render as filled/dark");
 });
 
+test("agent status badge fades out on hover so it doesn't collide with the save/copy/more toolbar in the same corner", () => {
+  const activity = ruleBody(".msg-activity");
+  assert.match(activity, /transition\s*:\s*opacity \.5s ease\b/, `activity badge should fade with the same timing as the toolbar it shares a corner with: ${activity}`);
+  const hoverFade = ruleBody(".msg:hover .msg-activity");
+  assert.match(hoverFade, /opacity\s*:\s*0\b/, `activity badge must yield the top-right corner to the toolbar on hover, not overlap it: ${hoverFade}`);
+});
+
 test("reaction footer keeps the upstream add-reaction entry even with no reactions", () => {
   assert.doesNotMatch(chatSrc, /if \(!rs\.length\) return null;/);
   assert.match(chatSrc, /<div className="msg-rx">/);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -601,7 +601,7 @@ aside.traj-col h2{position:relative;font-size:12px;font-weight:600;letter-spacin
 .agent-reply-placeholder.done{animation:none;color:var(--muted-soft);background:none}
 .agent-reply-placeholder.error{color:var(--status-red);font-style:normal;background:none;animation:none}
 @keyframes agent-thinking-shimmer{0%{background-position:100% 0}50%{background-position:0% 0}100%{background-position:0% 0}}
-.msg-activity{flex:none;font-family:var(--mono);font-size:11px;line-height:1.35;color:var(--muted);background:var(--status-badge-bg);border:0;border-radius:5px;padding:1px 5px;white-space:nowrap}
+.msg-activity{flex:none;font-family:var(--mono);font-size:11px;line-height:1.35;color:var(--muted);background:var(--status-badge-bg);border:0;border-radius:5px;padding:1px 5px;white-space:nowrap;transition:opacity .5s ease}
 .msg-activity.sleeping{color:var(--status-blue);background:var(--status-badge-bg)}
 .msg-activity.online,.msg-activity.active{color:var(--status-green);background:var(--status-badge-bg)}
 .msg-activity.working,.msg-activity.thinking{color:var(--status-orange);background:var(--status-badge-bg)}
@@ -838,6 +838,7 @@ aside.traj-col.profile-mode .scroll{flex:1;min-height:0;overflow:auto;margin:0 -
 /* ── Message hover floating toolbar (actions float in top-right corner) ──────────── */
 .msg-toolbar{position:absolute;top:7px;right:10px;display:flex;gap:2px;background:transparent;border:0;border-radius:8px;box-shadow:none;padding:0;opacity:0;pointer-events:none;transition:opacity .5s ease;z-index:5}
 .msg:hover .msg-toolbar{opacity:1;pointer-events:auto}
+.msg:hover .msg-activity{opacity:0} /* toolbar and the activity badge share the top-right corner; yield to the toolbar on hover instead of overlapping it */
 .msg-toolbar button{border:0;background:transparent;color:var(--muted);font-size:15px;line-height:1;padding:5px 7px;border-radius:6px;cursor:pointer}
 .msg-toolbar button:hover{background:var(--surface-strong)}
 .msg-toolbar button.on{color:var(--ink)}


### PR DESCRIPTION
## Summary
- `.msg-activity` (agent status badge) and `.msg-toolbar` (save/copy/more) both live in the top-right corner of the message row after #179 moved the badge into the header. Hovering revealed the toolbar overlapping the still-visible badge.
- Fade the badge to `opacity:0` on `.msg:hover`, matching the toolbar's existing `.5s` fade timing, so the toolbar cleanly takes over the corner instead of colliding with it.

## Test plan
- [x] `npm run typecheck` clean
- [x] Unit test suite 325/325 (`npx tsx --test --test-force-exit test/*.unit.test.ts src/daemon/*.test.ts`), including new regression test asserting the fade transition + hover rule
- [x] Live browser verification in an isolated worktree: seeded an agent message with a `thinking` status badge, confirmed via chrome-devtools hover — badge visible when not hovering, cleanly fades out while the toolbar fades in with no overlap