### PR TITLE
ci(publish): run daemon publish on Node 22 so npm@12 can install

### DIFF
--- a/.github/workflows/publish-daemon.yml
+++ b/.github/workflows/publish-daemon.yml
@@ -23,7 +23,11 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          # 22+: npm@12 (pulled in by the upgrade step below) refuses to install
+          # on Node 20 (EBADENGINE) — this broke the v0.9.0 publish. The daemon
+          # still supports node >=20 at runtime; 22 here is only the publish
+          # toolchain.
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
       - name: Upgrade npm (Trusted Publishing needs npm >= 11.5.1)


### PR DESCRIPTION
The v0.9.0 publish run failed: `npm install -g npm@latest` now resolves to npm@12, which requires Node >=22, but the job pinned Node 20 (EBADENGINE, run 29071124365). One-line fix: bump the publish toolchain to Node 22. Daemon runtime support stays at node >=20.

After merge: delete + recreate the v0.9.0 release pointing at the fixed main so the release event picks up this workflow version.