### PR TITLE
fix(daemon): wake nudge consumes queued delivers — stop double replies on cold-start wake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ from `main`; see commit history for fine-grained server/web changes.
 
 ## [Unreleased]
 
+## [0.10.2] — 2026-07-20
+
+### Fixed
+
+- **Agents no longer double-reply on cold-start wake**: a message that woke a sleeping/stopped
+  agent used to drive **two** turns — the wake nudge (STARTUP/RESUME) drove one, and the deliver
+  that had queued during workspace preparation was re-flushed as a `[inbox notice]` ~3 s later,
+  driving a second turn on the same (already-handled) message. Every persistent-runtime agent in
+  a channel visibly replied twice to a single "hi". Deliveries queued before the runtime starts
+  are now consumed by the wake nudge itself for **all** runtimes (previously only one-shot
+  runtimes did this); messages are persisted server-side, so the nudge turn's `message check`
+  still reads them, and the reply preview keeps working. Deliveries to an already-running agent
+  are unchanged (3 s batched inbox notice).
+
 ## [0.10.1] — 2026-07-19
 
 ### Fixed

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fancyboi999/open-tag-daemon",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "open-tag compute-plane daemon — connect any machine to an open-tag server so its agents run there. No repo clone needed.",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/daemon/agentManager.test.ts
+++ b/src/daemon/agentManager.test.ts
@@ -21,7 +21,48 @@ const baseConfig = (agentId: string): AgentConfig => ({
   agentToken: "test-token",
 });
 
-test("deliver received during async start is flushed to runtime session", async () => {
+test("deliver received during async start is consumed by the wake nudge, not re-delivered as a notice", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "open-tag-agent-manager-"));
+  const delivered: string[] = [];
+  const sent: any[] = [];
+  let initialPrompt: string | undefined;
+  const fakeRuntime: Runtime = {
+    name: "fake",
+    start(opts: StartOpts, cb: RuntimeCallbacks) {
+      initialPrompt = opts.initialPrompt;
+      cb.onSession("fake-session");
+      return { deliver: (text) => delivered.push(text), stop: () => {} };
+    },
+  };
+
+  try {
+    const mgr = new AgentManager((msg) => sent.push(msg), {
+      dataDir: root,
+      binDir: root,
+      deliverDebounceMs: 0,
+      budget: noPressureBudget,
+      runtimeResolver: () => fakeRuntime,
+    });
+    const start = mgr.start("agent-1", baseConfig("agent-1"));
+    mgr.deliver("agent-1", "User", "dm:agent-1", true, { targetName: "dm:Agent", msgShort: "m1" });
+    await start;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // The startup nudge itself drives the "check inbox" turn — the queued deliver
+    // must not produce a second in-session notice (that caused double replies).
+    assert.equal(delivered.length, 0);
+    assert.match(initialPrompt ?? "", /open-tag message check/);
+    // The reply preview still starts so the UI shows "agent is replying…".
+    const previewStart = sent.find((m) => m?.type === "agent:reply" && m?.op === "start");
+    assert.ok(previewStart, "expected an agent:reply start preview");
+    assert.equal(previewStart.channelId, "dm:agent-1");
+    mgr.stopAll();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("deliver while the agent is running still produces a batched inbox notice", async () => {
   const root = mkdtempSync(path.join(tmpdir(), "open-tag-agent-manager-"));
   const delivered: string[] = [];
   const fakeRuntime: Runtime = {
@@ -40,13 +81,12 @@ test("deliver received during async start is flushed to runtime session", async 
       budget: noPressureBudget,
       runtimeResolver: () => fakeRuntime,
     });
-    const start = mgr.start("agent-1", baseConfig("agent-1"));
+    await mgr.start("agent-1", baseConfig("agent-1"));
     mgr.deliver("agent-1", "User", "dm:agent-1", true, { targetName: "dm:Agent", msgShort: "m1" });
-    await start;
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     assert.equal(delivered.length, 1);
-    assert.match(delivered[0]!, /User/);
+    assert.match(delivered[0]!, /inbox notice/);
     assert.match(delivered[0]!, /dm:Agent/);
     mgr.stopAll();
   } finally {

--- a/src/daemon/agentManager.ts
+++ b/src/daemon/agentManager.ts
@@ -314,13 +314,16 @@ export class AgentManager {
     };
 
     // No await between set and runtime.start (single-threaded event loop), so deliver cannot interleave and read an empty session.
-    // Deliveries that arrived earlier during workspace preparation are flushed just below, except
-    // one-shot runtimes where the wakeup prompt itself is the concrete "check then send" turn.
+    // Deliveries queued during workspace preparation are consumed by the wake nudge itself: every
+    // initial prompt (STARTUP/RESUME/ONE_SHOT) already instructs an inbox check, so re-delivering
+    // them as an inbox notice would drive a second turn on the same message (agents visibly
+    // double-replied on cold start). Messages are persisted server-side — the nudge turn's
+    // `message check` pulls them; only the reply preview needs the queued metadata.
     const pendingDeliverItems = this.pendingDelivers.get(agentId)?.items ?? [];
     const pendingDeliveryCount = pendingDeliverItems.length;
     const useOneShotWakeNudge = !!runtime.oneShotWake && pendingDeliveryCount > 0;
     this.agents.set(agentId, running);
-    if (useOneShotWakeNudge) {
+    if (pendingDeliveryCount > 0) {
       const latest = pendingDeliverItems[pendingDeliverItems.length - 1];
       if (latest) this.startReplyPreview(agentId, running, latest.target, latest.meta.streamId);
     }
@@ -334,11 +337,9 @@ export class AgentManager {
     this.send({ type: "agent:activity", agentId, activity: "working", detail: "starting" });
     this.log.info("agent started", { agentId, runtime: runtime.name, model: config.model ?? "(default)", resume: !!config.sessionId, experimental: runtime.experimental ?? false });
     this.resetIdle(agentId);
-    if (useOneShotWakeNudge) {
+    if (pendingDeliveryCount > 0) {
       this.clearPendingDeliver(agentId);
-      this.log.debug("pending deliver consumed by one-shot wake nudge", { agentId, runtime: runtime.name, count: pendingDeliveryCount });
-    } else {
-      this.flushPendingDeliver(agentId);
+      this.log.debug("pending deliver consumed by wake nudge", { agentId, runtime: runtime.name, count: pendingDeliveryCount });
     }
   }
 
@@ -362,14 +363,6 @@ export class AgentManager {
     if (!q) return;
     clearTimeout(q.timer);
     this.pendingDelivers.delete(agentId);
-  }
-
-  private flushPendingDeliver(agentId: string): void {
-    const q = this.pendingDelivers.get(agentId);
-    if (!q) return;
-    this.clearPendingDeliver(agentId);
-    this.log.debug("pending deliver -> agent", { agentId, count: q.items.length });
-    for (const item of q.items) this.deliver(agentId, item.from, item.target, item.mentioned, item.meta);
   }
 
   private debounceMsFor(r: Running): number {


### PR DESCRIPTION
## Problem

One "大家都在吗" in a prod channel → every agent replied **twice** (3 agents = 6 replies).

Root cause: a message that wakes a sleeping/stopped agent drives **two turns** on persistent runtimes:

1. The wake nudge (`STARTUP_NUDGE`/`RESUME_NUDGE`) is the initial prompt → agent checks inbox, handles the message, replies. ✅
2. The `agent:deliver` that arrived while the workspace was still preparing had been queued (`deliver queued pending start`) and was **re-flushed into the running session** after start, landing 3 s later as a `[inbox notice: 1 unread…]` → a second turn on a message that was already consumed. The agent, told there's an unread it can't find, posts a filler reply.

`daemon.log` fingerprint (prod, 2026-07-20 08:30 UTC): `deliver queued pending start` → `agent started` → `pending deliver -> agent` → `inbox notice -> agent` (+3 s).

## Fix

Extend the existing one-shot consume path (`useOneShotWakeNudge`) to **all** runtimes: delivers queued before the runtime starts are consumed by the wake nudge itself — every nudge already instructs `open-tag message check`, and messages are persisted server-side, so nothing is lost. Only the reply preview keeps using the queued metadata (unchanged UX). `flushPendingDeliver` is now dead and removed.

**Unchanged:** deliveries to an already-running agent still batch (3 s) into an inbox notice; one-shot runtimes behave exactly as before; `agent:deliver:ack` timing untouched (acked at recv).

## Case matrix

| Case | Before | After |
|---|---|---|
| Persistent runtime, deliver during start (cold wake) | nudge turn + notice turn → **double reply** | nudge turn only, preview still shown |
| One-shot runtime, deliver during start | consumed by wake nudge | unchanged (test kept green) |
| Deliver while agent running (busy/idle) | 3 s batched inbox notice | unchanged (new regression test) |
| Start with no pending deliver | nudge only | unchanged |
| Pending-deliver TTL expiry before start | expire, `check` still finds msg | unchanged |

## Verification

- Unit (TDD, red→green): updated `deliver received during async start …` to assert the new contract (0 in-session notices, nudge prompt present, `agent:reply start` preview emitted) — **watched it fail** (`1 !== 0`) before the fix; added busy-path regression test. Full suite: **352/352 pass**, `npm run typecheck` clean.
- Live E2E (isolated worktree stack, real claude `@dev-bot`):
  - Cold-start `@dev-bot` mention → **exactly 1 reply**, 45 s grace window, log shows `pending deliver consumed by wake nudge`, **no** `inbox notice`.
  - Second message to the now-running agent → log shows `inbox notice -> agent`, exactly 1 reply.

Not verified: codex/one-shot runtimes live (covered by unit tests only); multi-message pending queue (>1 queued during prep) — same consume path, covered by unit shape but not live.

Daemon bundle behavior change → `packages/daemon` 0.10.1 → **0.10.2** + CHANGELOG entry. **Merged ≠ shipped**: needs a `v0.10.2` GitHub Release to publish npm, then daemon restarts on prod machines.
