### PR TITLE
fix(dev): wt-add writes absolute OPEN_TAG_PROJECT_ROOTS

### DIFF
--- a/scripts/wt-add.sh
+++ b/scripts/wt-add.sh
@@ -22,6 +22,7 @@ BASE="${WT_BASE:-origin/main}"
 echo "→ worktree=$WT  server=$SPORT  vite=$VPORT  db=$DB  redis=/$RDB  base=$BASE"
 git fetch origin main --quiet 2>/dev/null || true
 git worktree add "$WT" -b "feature/$NAME" "$BASE"
+WT_ABS=$(cd "$WT" && pwd)
 docker compose exec -T postgres createdb -U opentag "$DB" 2>/dev/null || echo "  (db $DB already exists, reusing)"
 
 # Generate random secrets for each worktree — never reuse the weak defaults
@@ -37,7 +38,7 @@ REDIS_URL=redis://localhost:6380/$RDB
 JWT_SECRET=$WT_JWT_SECRET
 DAEMON_BOOTSTRAP_KEY=$WT_BOOTSTRAP_KEY
 OPEN_TAG_HOME=$HOME/.open-tag-$SAFE
-OPEN_TAG_PROJECT_ROOTS=$WT
+OPEN_TAG_PROJECT_ROOTS=["$WT_ABS"]
 ALLOW_DEV_LOGIN=true
 EOF
 


### PR DESCRIPTION
## Summary

Fixes a broken dev-flow bug split out of PR #201 (Reasonix integration) per review feedback — these changes are unrelated to the Reasonix adapter and tracked separately to keep #201's review/regression scope focused.

`scripts/wt-add.sh` wrote the worktree-relative path (`$WT = ../open-tag-<name>`) into `OPEN_TAG_PROJECT_ROOTS`. `projectDirectory.ts` rejects any non-absolute root, so every worktree daemon failed both the folder picker (`project:browse` → `project_roots_not_configured`) and manual absolute-path entry (`project:resolve` → same throw). This writes an absolute JSON-array value computed from the created worktree.

## Verification

- Root + web typecheck clean.
- Manual: worktree spun up via `wt:add` now produces an absolute `OPEN_TAG_PROJECT_ROOTS` in `.env`; project picker + manual-path resolve succeed where they previously threw.