### PR TITLE
fix(web): ignore stale search responses

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -98,7 +98,7 @@
 
 ## P7 Advanced
 - [ ] **knowledge (agent private knowledge base / memo)**: agents **create multiple** memos (`title`+`content`), full-text **search** (PG tsvector) for self-retrieval during work — audience is **the agent itself**, not humans, **not** a read-only platform manual. Schema `knowledge` table direction correct; missing endpoints + `open-tag knowledge` CLI (create/list/search) + GIN index
-- [x] **messages search (human search)**: `GET /api/messages/search?q=` (scoped to the caller's readable channels, ilike + snippet + `hasMore` paging) + web Search view; **not the same as knowledge**, do not conflate
+- [x] **messages search (human search)**: `GET /api/messages/search?q=` (scoped to the caller's readable channels, ilike + snippet + `hasMore` paging) + web Search view (300ms debounce; only the current query may commit results, so slower stale responses cannot overwrite newer or cleared input); **not the same as knowledge**, do not conflate
 - [ ] integrations / apps, credential proxy (agents never touch plaintext keys)
 - [ ] Agent wake-hints/stream (out-of-process real-time push to agents; agents already talk to the real `/agent-api` via the CLI)
 - [ ] Web Push (vapid)

--- a/test/searchStaleResponse.unit.test.ts
+++ b/test/searchStaleResponse.unit.test.ts
@@ -1,0 +1,20 @@
+// Unit regression for stale human-search responses overwriting the current query.
+// Run: npx tsx --test --test-force-exit test/searchStaleResponse.unit.test.ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const miscSrc = fs.readFileSync(new URL("../web/src/views/misc.tsx", import.meta.url), "utf8");
+const searchSrc = /export function Search\(\)[\s\S]*?\n}\n\n\/\/ Settings sub-pages/.exec(miscSrc)?.[0] ?? "";
+
+test("search drops an in-flight response after the query changes or clears", () => {
+  assert.match(searchSrc, /let cancelled = false/);
+  assert.match(
+    searchSrc,
+    /const d = await api\([\s\S]*?if \(cancelled\) return;[\s\S]*?setResults\([\s\S]*?setSearched\(true\)/,
+  );
+  assert.match(
+    searchSrc,
+    /return \(\) => \{[\s\S]*?cancelled = true;[\s\S]*?clearTimeout\(h\);[\s\S]*?}/,
+  );
+});

--- a/web/src/views/misc.tsx
+++ b/web/src/views/misc.tsx
@@ -315,8 +315,14 @@ export function Search() {
   useEffect(() => {
     const v = q.trim();
     if (!v) { setResults([]); setSearched(false); return; }
-    const h = setTimeout(async () => { const d = await api("GET", `/api/messages/search?q=${encodeURIComponent(v)}`); setResults(d?.results || []); setSearched(true); }, 300);
-    return () => clearTimeout(h);
+    let cancelled = false;
+    const h = setTimeout(async () => {
+      const d = await api("GET", `/api/messages/search?q=${encodeURIComponent(v)}`);
+      if (cancelled) return;
+      setResults(d?.results || []);
+      setSearched(true);
+    }, 300);
+    return () => { cancelled = true; clearTimeout(h); };
   }, [q]);
   return (
     <>


### PR DESCRIPTION
## Summary

- invalidate an in-flight search when the query changes or clears
- prevent a late response from repopulating stale results

## Verification

- production web/docs build
- `npm run typecheck`
- stale-response regression test passing

## Documentation

- updated `FEATURES.md`

