### PR TITLE
fix(db): load ENV_FILE before QA seed database

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -92,7 +92,7 @@ Lets any machine join a server without cloning the repo: `npx @fancyboi999/open-
 ### Data / shared (`src/`)
 
 - `db/schema.ts` — **Data model** (Drizzle). Canonical field truth; change data structures here first.
-- `db/index.ts` / `db/seed.ts` — DB handle (drizzle + postgres) / seed data.
+- `db/index.ts` / `db/seed.ts` / `db/seed-dev.ts` / `db/qa-seed.ts` — DB handle (drizzle + postgres) / seed data; every standalone seed imports `env.ts` before `db/index.ts` so `ENV_FILE` selects the intended database.
 - `redis.ts` — `nextSeq` (INCR `seq:{server}`) / `nextTaskNumber(serverId, channel?)` (INCR a scope key from `taskNumberKey`: `tasknum:dm:{channelId}` for DMs, `tasknum:{server}` otherwise) / `reconcileCounters` (boot-time durability guard: advances seq + every task-number scope to the live Postgres max) / `publishEvent` (pub/sub real-time fan-out, SSE subscribes `events:{server}`) / `pokeAgent` (RPUSH `wake:{agentId}`, wakes agent's BLPOP long-poll).
 - `env.ts` — Loads root `.env` (**must be the first import** in any module that reads `process.env`; does not override variables already set in the shell environment).
 - `log.ts` — Unified logger writing JSONL to `~/.open-tag/logs/` and human-readable console lines to stdout/stderr: non-error server/daemon logs go to stdout so platform loggers do not classify debug/info as errors, true errors go to stderr, and CLI logs stay on stderr so agent-readable command stdout remains clean.

--- a/src/db/qa-seed.ts
+++ b/src/db/qa-seed.ts
@@ -1,6 +1,7 @@
 // Clean QA environment: qa workspace + owner + dedicated machine key + two Claude agents + #general.
 // The QA daemon uses QA_KEY, so it remains isolated from the default workspace bootstrap key.
 // Run this seed, then start the daemon with --api-key qa-machine-key.
+import "../env.js";
 import { db, schema, sql } from "./index.js";
 import { hashToken } from "../server/auth.js";
 import { eq, and } from "drizzle-orm";

--- a/test/qaSeedEnv.unit.test.ts
+++ b/test/qaSeedEnv.unit.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const source = readFileSync(new URL("../src/db/qa-seed.ts", import.meta.url), "utf8");
+
+test("qa seed loads ENV_FILE before constructing the database client", () => {
+  const envImport = source.indexOf('import "../env.js"');
+  const dbImport = source.indexOf('from "./index.js"');
+
+  assert.notEqual(envImport, -1, "qa-seed must load src/env.ts");
+  assert.ok(envImport < dbImport, "the env side effect must run before db/index.ts reads DATABASE_URL");
+});


### PR DESCRIPTION
## Summary

- load `src/env.ts` before `db/index.ts` in the standalone QA seed
- ensure `ENV_FILE` selects the intended database instead of silently falling back to the local development URL
- add a regression test for the load-order contract

## Verification

- RED: the regression test failed on the old source with `qa-seed must load src/env.ts`
- production Docker build
- `npm run typecheck`
- focused regression test (1/1 passing)
- full CI-style unit suite on the cumulative personal branch (450/450 passing)
- daemon bundle build

The destructive QA seed itself was not run against a live database because it intentionally inserts fixture data.

## Doc sync

- updated the Data codemap in `ARCHITECTURE.md`
- no schema, product feature, or user-flow docs changed
- no AOCI artifacts are included
