### PR TITLE
fix(web): ignore stale search responses

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -99,7 +99,7 @@
 
 ## P7 Advanced
 - [ ] **knowledge (agent private knowledge base / memo)**: agents **create multiple** memos (`title`+`content`), full-text **search** (PG tsvector) for self-retrieval during work — audience is **the agent itself**, not humans, **not** a read-only platform manual. Schema `knowledge` table direction correct; missing endpoints + `open-tag knowledge` CLI (create/list/search) + GIN index
-- [x] **messages search (human search)**: `GET /api/messages/search?q=` (scoped to the caller's readable channels, ilike + snippet + `hasMore` paging) + web Search view; **not the same as knowledge**, do not conflate
+- [x] **messages search (human search)**: `GET /api/messages/search?q=` (scoped to the caller's readable channels, ilike + snippet + `hasMore` paging) + web Search view (300ms debounce; only the current query may commit results, so slower stale responses cannot overwrite newer or cleared input); **not the same as knowledge**, do not conflate
 - [ ] integrations / apps, credential proxy (agents never touch plaintext keys)
 - [ ] Agent wake-hints/stream (out-of-process real-time push to agents; agents already talk to the real `/agent-api` via the CLI)
 - [ ] Web Push (vapid)

--- a/test/searchStaleResponse.unit.test.ts
+++ b/test/searchStaleResponse.unit.test.ts
@@ -1,0 +1,22 @@
+// Unit regression for stale human-search responses overwriting the current query.
+// Run: npx tsx --test --test-force-exit test/searchStaleResponse.unit.test.ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const miscSrc = fs
+  .readFileSync(new URL("../web/src/views/misc.tsx", import.meta.url), "utf8")
+  .replace(/\r\n?/g, "\n");
+const searchSrc = /export function Search\(\)[\s\S]*?\n}\n\n\/\/ Settings sub-pages/.exec(miscSrc)?.[0] ?? "";
+
+test("search drops an in-flight response after the query changes or clears", () => {
+  assert.match(searchSrc, /let cancelled = false/);
+  assert.match(
+    searchSrc,
+    /const d = await api\([\s\S]*?if \(cancelled\) return;[\s\S]*?setResults\([\s\S]*?setSearched\(true\)/,
+  );
+  assert.match(
+    searchSrc,
+    /return \(\) => \{[\s\S]*?cancelled = true;[\s\S]*?clearTimeout\(h\);[\s\S]*?}/,
+  );
+});

--- a/web/src/views/misc.tsx
+++ b/web/src/views/misc.tsx
@@ -319,8 +319,14 @@ export function Search() {
   useEffect(() => {
     const v = q.trim();
     if (!v) { setResults([]); setSearched(false); return; }
-    const h = setTimeout(async () => { const d = await api("GET", `/api/messages/search?q=${encodeURIComponent(v)}`); setResults(d?.results || []); setSearched(true); }, 300);
-    return () => clearTimeout(h);
+    let cancelled = false;
+    const h = setTimeout(async () => {
+      const d = await api("GET", `/api/messages/search?q=${encodeURIComponent(v)}`);
+      if (cancelled) return;
+      setResults(d?.results || []);
+      setSearched(true);
+    }, 300);
+    return () => { cancelled = true; clearTimeout(h); };
   }, [q]);
   return (
     <>


### PR DESCRIPTION
## Summary

- Ignore an in-flight message-search response after the query changes, clears, or the Search view unmounts.
- Keep the existing 300 ms debounce and allow only the current query to commit results.
- Add a regression test with cross-platform line-ending normalization and update the feature description.

## Commit structure

1. `fix(web): ignore stale search responses` — Search cancellation guard plus the matching `FEATURES.md` contract.
2. `test(web): cover stale search response cancellation` — focused cross-platform regression coverage.

## Scope

Three files: the Search view, its focused regression test, and `FEATURES.md`. No API, database, daemon, dependency, or authorization changes.

## Verification

- `npx -y node@22 node_modules/tsx/dist/cli.mjs --test --test-force-exit test/searchStaleResponse.unit.test.ts` — 1/1 passed.
- `npm run typecheck` — root and web passed.
- `npm run web:build` — production build and prerender passed, 2,553 modules transformed.
- In-memory Windows CRLF simulation — reproduced the old empty source extraction; normalization restored the Search extraction and all three regression assertions passed.
- Browser verification against `http://192.168.100.123:7788`:
  - Real login, Search page, and `GET /api/messages/search?q=a` all returned 200 and rendered search state (4/4 assertions).
  - Deterministic delayed-A / fast-B response ordering kept B visible after A completed last (8/8 assertions).
  - Three inputs 90 ms apart issued exactly one request for the final query (5/5 assertions).
  - Clearing input while an old request was in flight kept the UI empty after that response completed (6/6 assertions).
- Browser race responses were intercepted only to control timing; the production check performed no writes and changed no production data.

## CI for `b4aebee`

- Ubuntu `typecheck-and-build` — passed in 54 seconds.
- Windows `typecheck-and-build` — passed in 1 minute 38 seconds.

## Not applicable

No daemon restart/release, database migration, or authorization matrix verification is required for this frontend-only change.