### PR TITLE
fix(server): sweeper auto-cleans stale supervisor notices per turn

### DIFF
--- a/src/server/core.ts
+++ b/src/server/core.ts
@@ -678,10 +678,25 @@ export async function sweepOrphanedAgentDeliveries(at = new Date()): Promise<num
   for (const r of rows) {
     const deliveryId = `${r.turnId}:${r.agentId}`;
     if (hasPendingAgentDelivery(deliveryId)) continue; // a live process still owns this delivery
+    const short = r.turnId.slice(0, 8);
+    // At most ONE auto-recovery per turn: a prior 🛠/⛔ notice for this turn means we already
+    // recovered it and it stalled AGAIN (delivered but the agent never answered — a slow or
+    // wedged agent, not a lost delivery). Re-releasing would loop forever and flood the
+    // channel (live 2026-08-17: 482 notices for one turn). Escalate to a human instead.
+    const prior = await db.select({ id: schema.messages.id }).from(schema.messages)
+      .where(and(eq(schema.messages.channelId, r.channelId), eq(schema.messages.messageType, "system"), like(schema.messages.content, `%turn ${short}%`))).limit(1);
+    if (prior.length) {
+      const esc = await db.update(schema.conversationTurns).set({ state: "blocked", dispatchLeaseUntil: null, updatedAt: at })
+        .where(and(eq(schema.conversationTurns.id, r.turnId), inArray(schema.conversationTurns.state, ["ready", "dispatching", "active", "dispatched"])))
+        .returning({ id: schema.conversationTurns.id });
+      if (esc.length) await sysTaskMsg(r.serverId, r.channelId, `⛔ 监工:turn ${short} 恢复后仍无活动,已停止自动恢复,需人工处理(supervisor: repeated delivery stall escalated to human)`);
+      recovered++;
+      continue;
+    }
     await releaseAgentDeliveryAdmission({ deliveryId, messageId: r.messageId, agentId: r.agentId, seq: 0 });
     await db.update(schema.conversationTurns).set({ state: "ready", dispatchAfter: at, dispatchLeaseUntil: null, updatedAt: at })
       .where(and(eq(schema.conversationTurns.id, r.turnId), inArray(schema.conversationTurns.state, ["dispatching", "active", "dispatched"])));
-    await sysTaskMsg(r.serverId, r.channelId, `🛠 监工:投递许可超时已自动恢复(supervisor: orphaned delivery admission released, turn ${r.turnId.slice(0, 8)})`);
+    await sysTaskMsg(r.serverId, r.channelId, `🛠 监工:投递许可超时已自动恢复(supervisor: orphaned delivery admission released, turn ${short})`);
     recovered++;
   }
   return recovered;

--- a/src/server/core.ts
+++ b/src/server/core.ts
@@ -684,7 +684,16 @@ export async function sweepOrphanedAgentDeliveries(at = new Date()): Promise<num
     // wedged agent, not a lost delivery). Re-releasing would loop forever and flood the
     // channel (live 2026-08-17: 482 notices for one turn). Escalate to a human instead.
     const prior = await db.select({ id: schema.messages.id }).from(schema.messages)
-      .where(and(eq(schema.messages.channelId, r.channelId), eq(schema.messages.messageType, "system"), like(schema.messages.content, `%turn ${short}%`))).limit(1);
+      .where(and(eq(schema.messages.channelId, r.channelId), eq(schema.messages.messageType, "system"), like(schema.messages.content, `%turn ${short}%`)));
+    // Auto-clean stale supervisor notices for this turn (live 2026-08-17: old 🛠 rows accumulated
+    // and flooded the channel/context). Only the notice we post below may survive.
+    for (const o of prior) {
+      await db.delete(schema.agentMessageObservations).where(eq(schema.agentMessageObservations.messageId, o.id));
+      await db.delete(schema.agentMessageDecisions).where(eq(schema.agentMessageDecisions.messageId, o.id));
+      await db.delete(schema.messageMentions).where(eq(schema.messageMentions.messageId, o.id));
+      await db.delete(schema.conversationTurns).where(eq(schema.conversationTurns.triggerMessageId, o.id));
+      await db.delete(schema.messages).where(eq(schema.messages.id, o.id));
+    }
     if (prior.length) {
       const esc = await db.update(schema.conversationTurns).set({ state: "blocked", dispatchLeaseUntil: null, updatedAt: at })
         .where(and(eq(schema.conversationTurns.id, r.turnId), inArray(schema.conversationTurns.state, ["ready", "dispatching", "active", "dispatched"])))

--- a/src/server/core.ts
+++ b/src/server/core.ts
@@ -1,5 +1,7 @@
 // Message core: seq assignment, @mention parsing, DB write, SSE broadcast (human), wake delivery (agent), target resolution.
-import { and, eq, ne, desc, gt, inArray, like, sql, or, isNull, isNotNull } from "drizzle-orm";
+import { and, eq, ne, desc, gt, lte, inArray, like, sql, or, isNull, isNotNull } from "drizzle-orm";
+import { releaseAgentDeliveryAdmission } from "./agentDeliveryAdmission.js";
+import { hasPendingAgentDelivery } from "./agentDeliveryAck.js";
 import { db, schema } from "../db/index.js";
 import { nextSeq, publish } from "./realtime.js";
 import { nextTaskNumber } from "../redis.js";
@@ -637,6 +639,60 @@ async function sysTaskMsg(serverId: string, channelId: string, content: string, 
   await publish(serverId, { type: "message", channelId, message: { ...serializeMsg(m!, [], []), channelType: ch?.type ?? null } });
   await publishThreadUpdated(serverId, ch, actor?.id ?? null, "system");
   return m!;
+}
+
+/** Channel-deletion notice for member agents: a system message inside the (just deleted)
+ *  channel plus assigned attention per agent, so each member is woken and sees it via
+ *  message check — the agent plane surfaces ONLY post-deletion system messages for deleted
+ *  channels (routes-agent check), so members learn the channel is gone without regaining
+ *  history visibility, and sends stay rejected by resolveTarget (live 2026-08-16 #实验频道). */
+export async function notifyChannelDeleted(serverId: string, channelId: string, channelName: string, agentIds: string[]): Promise<void> {
+  if (!agentIds.length) return;
+  const m = await sysTaskMsg(serverId, channelId, `频道 #${channelName} 已被删除 / channel #${channelName} has been deleted`);
+  await ensureReplyRecipients({ serverId, channelId, messageId: m.id, recipients: agentIds.map((agentId) => ({ agentId, attention: "assigned" as const })) });
+}
+
+/** Watchdog sweeper: recover deliveries orphaned by a server restart. The admitted row
+ *  survives in DB while no live process awaits the agent's reply, so every later dispatch
+ *  short-circuits "delivered" (conversationTurnDispatch) and the turn never actually reaches
+ *  the agent (live 2026-08-16 18:20 stall). Release the admission + re-ready the turn; the
+ *  scheduler redelivers on its next tick, and a system notice keeps the recovery visible. */
+const ORPHAN_DELIVERY_GRACE_MS = 60_000;
+export async function sweepOrphanedAgentDeliveries(at = new Date()): Promise<number> {
+  const cutoff = new Date(at.getTime() - ORPHAN_DELIVERY_GRACE_MS);
+  const rows = await db.select({
+    messageId: schema.agentMessageDecisions.messageId,
+    agentId: schema.agentMessageDecisions.agentId,
+    turnId: schema.conversationTurns.id,
+    channelId: schema.conversationTurns.channelId,
+    serverId: schema.conversationTurns.serverId,
+  }).from(schema.agentMessageDecisions)
+    .innerJoin(schema.conversationTurns, eq(schema.conversationTurns.triggerMessageId, schema.agentMessageDecisions.messageId))
+    .where(and(
+      isNotNull(schema.agentMessageDecisions.deliveryAdmittedAt),
+      lte(schema.agentMessageDecisions.deliveryAdmittedAt, cutoff),
+      isNull(schema.agentMessageDecisions.replyMessageId),
+      inArray(schema.conversationTurns.state, ["dispatching", "active", "dispatched"]),
+    ));
+  let recovered = 0;
+  for (const r of rows) {
+    const deliveryId = `${r.turnId}:${r.agentId}`;
+    if (hasPendingAgentDelivery(deliveryId)) continue; // a live process still owns this delivery
+    await releaseAgentDeliveryAdmission({ deliveryId, messageId: r.messageId, agentId: r.agentId, seq: 0 });
+    await db.update(schema.conversationTurns).set({ state: "ready", dispatchAfter: at, dispatchLeaseUntil: null, updatedAt: at })
+      .where(and(eq(schema.conversationTurns.id, r.turnId), inArray(schema.conversationTurns.state, ["dispatching", "active", "dispatched"])));
+    await sysTaskMsg(r.serverId, r.channelId, `🛠 监工:投递许可超时已自动恢复(supervisor: orphaned delivery admission released, turn ${r.turnId.slice(0, 8)})`);
+    recovered++;
+  }
+  return recovered;
+}
+
+export function startStuckTurnSweeper(): void {
+  const tick = () => sweepOrphanedAgentDeliveries()
+    .then((n) => { if (n > 0) log.info("stuck-turn sweeper recovered orphaned deliveries", { n }); })
+    .catch((e) => log.warn("stuck-turn sweeper failed (continuing)", { detail: String((e as Error)?.message ?? e) }));
+  setInterval(tick, 60_000);
+  void tick();
 }
 
 export async function convertMessageToTask(serverId: string, messageId: string, by?: { type: "user" | "agent"; id: string }) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -16,7 +16,7 @@ import { reconcileMachinesOnBoot, startMachineSweeper } from "./machineLiveness.
 import { sendJson, sendErr } from "./util.js";
 import { createLogger } from "../log.js";
 import { shouldServeAppShell } from "./staticRoutes.js";
-import { dispatchConversationTurn } from "./core.js";
+import { dispatchConversationTurn, startStuckTurnSweeper } from "./core.js";
 import { startConversationTurnScheduler } from "./conversationTurns.js";
 
 // ── Security headers (helmet) ────────────────────────────────────────────────
@@ -146,6 +146,7 @@ const server = http.createServer(async (req, res) => {
 attachSocketIO(server); // human-side realtime (socket.io, /socket.io/)
 attachWs(server);       // daemon control plane (raw ws, /daemon/connect)
 startReminderScheduler(); // reminder scheduler: fires at due time, wakes the author
+startStuckTurnSweeper(); // watchdog: releases restart-orphaned delivery admissions, re-readies turns
 
 // Durability guard: before accepting traffic, advance Redis seq/tasknum counters to match the current Postgres maximum.
 // Prevents seq collisions and silent message drops in /messages/sync if Redis loses data (flush/instance swap/eviction) and INCR restarts from a lower value.

--- a/test/stuckTurnSweeper.integration.ts
+++ b/test/stuckTurnSweeper.integration.ts
@@ -90,7 +90,7 @@ async function main() {
   const [ot2] = await db.select().from(schema.conversationTurns).where(eq(schema.conversationTurns.id, orphanTurn));
   check("re-stalled turn escalates to blocked instead of looping", ot2!.state === "blocked");
   const sys = await db.select().from(schema.messages).where(and(eq(schema.messages.channelId, chId), eq(schema.messages.messageType, "system")));
-  check("exactly one 🛠 and one ⛔ notice (no flood)", sys.filter((s) => s.content.includes("🛠")).length === 1 && sys.filter((s) => s.content.includes("⛔")).length === 1);
+  check("stale 🛠 auto-cleaned, single ⛔ remains", sys.filter((s) => s.content.includes("🛠")).length === 0 && sys.filter((s) => s.content.includes("⛔")).length === 1);
 
   // A blocked turn is never swept again.
   const n2 = await sweepOrphanedAgentDeliveries();

--- a/test/stuckTurnSweeper.integration.ts
+++ b/test/stuckTurnSweeper.integration.ts
@@ -79,7 +79,23 @@ async function main() {
   check("fresh turn state untouched", ft!.state === "dispatched");
 
   const notice = await db.select().from(schema.messages).where(and(eq(schema.messages.channelId, chId), eq(schema.messages.messageType, "system")));
-  check("recovery posts a visible supervisor notice", notice.length === 1 && notice[0]!.content.includes("监工"));
+  check("recovery posts a visible supervisor notice", notice.length === 1 && notice[0]!.content.includes("🛠"));
+
+  // Second stall of the SAME turn (delivered but agent never answered): the sweeper must NOT
+  // recover/notify again — it escalates once to blocked + ⛔ and stops (live 2026-08-17 flood).
+  await db.update(schema.agentMessageDecisions).set({ deliveryAdmittedAt: new Date(Date.now() - 5 * 60_000) })
+    .where(and(eq(schema.agentMessageDecisions.messageId, orphanMsg), eq(schema.agentMessageDecisions.agentId, agentId)));
+  await db.update(schema.conversationTurns).set({ state: "dispatched" }).where(eq(schema.conversationTurns.id, orphanTurn));
+  await sweepOrphanedAgentDeliveries();
+  const [ot2] = await db.select().from(schema.conversationTurns).where(eq(schema.conversationTurns.id, orphanTurn));
+  check("re-stalled turn escalates to blocked instead of looping", ot2!.state === "blocked");
+  const sys = await db.select().from(schema.messages).where(and(eq(schema.messages.channelId, chId), eq(schema.messages.messageType, "system")));
+  check("exactly one 🛠 and one ⛔ notice (no flood)", sys.filter((s) => s.content.includes("🛠")).length === 1 && sys.filter((s) => s.content.includes("⛔")).length === 1);
+
+  // A blocked turn is never swept again.
+  const n2 = await sweepOrphanedAgentDeliveries();
+  const sys2 = await db.select().from(schema.messages).where(and(eq(schema.messages.channelId, chId), eq(schema.messages.messageType, "system")));
+  check("blocked turn stays silent on later sweeps", sys2.length === sys.length && n2 >= 0);
 }
 
 main()

--- a/test/stuckTurnSweeper.integration.ts
+++ b/test/stuckTurnSweeper.integration.ts
@@ -1,0 +1,95 @@
+// Real DB integration: a server restart can orphan a committed delivery admission —
+// the row keeps delivery_admitted_at while no live process awaits the reply, so every
+// later dispatch short-circuits "delivered" and the turn never reaches the agent
+// (live 2026-08-16 18:20 stall). sweepOrphanedAgentDeliveries must release it and
+// re-ready the turn; fresh admissions and in-process-owned deliveries stay untouched.
+// Requires infra up: `npm run infra` (pg :5433, redis :6380). Run: npx tsx test/stuckTurnSweeper.integration.ts
+import crypto from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { db, schema } from "../src/db/index.ts";
+import { sweepOrphanedAgentDeliveries } from "../src/server/core.ts";
+
+const ts = Date.now();
+let serverId = "", ownerId = "", agentId = "", chId = "";
+let orphanMsg = "", orphanTurn = "", freshMsg = "", freshTurn = "";
+let failures = 0;
+const check = (label: string, cond: boolean) => { console.log(`  ${cond ? "✔" : "✗ FAIL"} ${label}`); if (!cond) failures++; };
+
+async function seedTurn(tag: string, admittedAt: Date | null): Promise<{ msg: string; turn: string }> {
+  const [m] = await db.insert(schema.messages).values({
+    seq: 1, serverId, channelId: chId, senderType: "user", senderId: ownerId, senderName: "owner",
+    content: `trigger ${tag}`, searchText: `trigger ${tag}`,
+  }).returning();
+  const rootId = crypto.randomUUID();
+  const [t] = await db.insert(schema.conversationTurns).values({
+    id: rootId, causalRootId: rootId,
+    serverId, channelId: chId, senderType: "user", senderId: ownerId,
+    anchorMessageId: m!.id, triggerMessageId: m!.id, latestMessageId: m!.id,
+    firstSeq: 1, lastSeq: 1, state: "dispatched", dispatchAfter: new Date(Date.now() - 60_000),
+  }).returning();
+  await db.insert(schema.agentMessageDecisions).values({
+    serverId, channelId: chId, messageId: m!.id, agentId, attention: "dm",
+    ...(admittedAt ? { deliveryAdmittedAt: admittedAt } : {}),
+  });
+  return { msg: m!.id, turn: t!.id };
+}
+
+async function setup() {
+  const [u] = await db.insert(schema.users).values({ name: `owner_${ts}`, displayName: "Owner", email: `o_${ts}@t.local` }).returning();
+  ownerId = u!.id;
+  const [srv] = await db.insert(schema.servers).values({ name: "T", slug: `t-${ts}`, ownerId }).returning();
+  serverId = srv!.id;
+  await db.insert(schema.serverMembers).values({ serverId, userId: ownerId, role: "owner" });
+  const [ag] = await db.insert(schema.agents).values({ serverId, name: `stuck_${ts}`, displayName: "Stuck" }).returning();
+  agentId = ag!.id;
+  const [c] = await db.insert(schema.channels).values({ serverId, name: `stuck_${ts}`, type: "channel" }).returning();
+  chId = c!.id;
+  const o = await seedTurn("orphan", new Date(Date.now() - 5 * 60_000));
+  orphanMsg = o.msg; orphanTurn = o.turn;
+  const f = await seedTurn("fresh", new Date());
+  freshMsg = f.msg; freshTurn = f.turn;
+}
+
+async function cleanup() {
+  await db.delete(schema.agentMessageDecisions).where(eq(schema.agentMessageDecisions.serverId, serverId));
+  await db.delete(schema.conversationTurns).where(eq(schema.conversationTurns.serverId, serverId));
+  await db.delete(schema.messages).where(eq(schema.messages.serverId, serverId));
+  await db.delete(schema.channels).where(eq(schema.channels.serverId, serverId));
+  await db.delete(schema.agents).where(eq(schema.agents.serverId, serverId));
+  await db.delete(schema.serverMembers).where(eq(schema.serverMembers.serverId, serverId));
+  await db.delete(schema.servers).where(eq(schema.servers.id, serverId));
+  await db.delete(schema.users).where(eq(schema.users.id, ownerId));
+}
+
+async function main() {
+  await setup();
+  const n = await sweepOrphanedAgentDeliveries();
+  // The sweeper is global by design (all servers); the shared dev DB may hold orphans from
+  // other test runs, so assert >=1 here and exactness via the per-row checks below.
+  check(`sweep recovers the orphaned delivery (n=${n})`, n >= 1);
+
+  const [od] = await db.select().from(schema.agentMessageDecisions).where(and(eq(schema.agentMessageDecisions.messageId, orphanMsg), eq(schema.agentMessageDecisions.agentId, agentId)));
+  check("orphan admission released", od!.deliveryAdmittedAt === null);
+  const [ot] = await db.select().from(schema.conversationTurns).where(eq(schema.conversationTurns.id, orphanTurn));
+  check("orphan turn re-ready for redelivery", ot!.state === "ready");
+
+  const [fd] = await db.select().from(schema.agentMessageDecisions).where(and(eq(schema.agentMessageDecisions.messageId, freshMsg), eq(schema.agentMessageDecisions.agentId, agentId)));
+  check("fresh admission untouched", fd!.deliveryAdmittedAt !== null);
+  const [ft] = await db.select().from(schema.conversationTurns).where(eq(schema.conversationTurns.id, freshTurn));
+  check("fresh turn state untouched", ft!.state === "dispatched");
+
+  const notice = await db.select().from(schema.messages).where(and(eq(schema.messages.channelId, chId), eq(schema.messages.messageType, "system")));
+  check("recovery posts a visible supervisor notice", notice.length === 1 && notice[0]!.content.includes("监工"));
+}
+
+main()
+  .then(cleanup)
+  .then(() => {
+    if (failures > 0) {
+      console.log(`\n${failures} CHECK(S) FAILED ❌`);
+    } else {
+      console.log("\nALL PASS ✅");
+    }
+    process.exit(failures === 0 ? 0 : 1);
+  })
+  .catch(async (e) => { console.error("ERROR:", e); try { await cleanup(); } catch { /**/ } process.exit(1); });


### PR DESCRIPTION
Split PR. stacked: includes up/20 (sweeper)

AOCI cognition index files deliberately excluded. Typecheck + targeted integration tests green.