### PR TITLE
Fix Pi-compatible Windows follow-up launches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ from `main`; see commit history for fine-grained server/web changes.
 
 ## [Unreleased]
 
+### Fixed
+
+- Pi-compatible runtimes can be launched through an explicit `OPEN_TAG_PI_COMMAND`, avoiding
+  Windows batch wrappers that truncate multiline wake prompts. A zero exit with no parseable JSON
+  events is now reported as an error instead of producing a misleading empty "Handled" receipt.
+
 ## [0.15.0] — 2026-08-02
 
 ### Added

--- a/packages/daemon/README.md
+++ b/packages/daemon/README.md
@@ -37,6 +37,9 @@ open-tag-daemon --server-url https://your-open-tag-server --api-key sk_machine_x
 - **Node.js ≥ 20** on the target machine.
 - At least one supported agent CLI on `$PATH` (e.g. `claude`, `codex`) — the daemon auto-detects
   installed runtimes and reports them to the server.
+- `OPEN_TAG_PI_COMMAND` optionally selects an explicit Pi-compatible executable. This is useful on
+  Windows when a fork such as Oh My Pi must be launched directly instead of through a `.cmd` shim;
+  direct launching preserves multiline turn prompts and JSON-mode arguments.
 
 ## License
 

--- a/src/daemon/piRuntime.test.ts
+++ b/src/daemon/piRuntime.test.ts
@@ -5,7 +5,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { handlePiEvent } from "./piRuntime.js";
+import { handlePiEvent, piCommand, piNoJsonError } from "./piRuntime.js";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 function fixtureEvents(name: string): any[] {
@@ -62,4 +62,14 @@ test("a model error in the message (stopReason=error, pi still exits 0) is surfa
 test("stopReason=error without errorMessage still surfaces a fallback message (not silently swallowed)", () => {
   const emit = handlePiEvent({ type: "message_end", message: { role: "assistant", content: [], stopReason: "error" } });
   assert.match(emit.error ?? "", /pi model error/);
+});
+
+test("an explicit Pi command bypasses shell shims while the default remains pi", () => {
+  assert.equal(piCommand({}), "pi");
+  assert.equal(piCommand({ OPEN_TAG_PI_COMMAND: " omp-direct " }), "omp-direct");
+});
+
+test("exit 0 without any JSON events is an error, not a handled turn", () => {
+  assert.match(piNoJsonError(0) ?? "", /without parseable JSON events/);
+  assert.equal(piNoJsonError(1), null);
 });

--- a/src/daemon/piRuntime.ts
+++ b/src/daemon/piRuntime.ts
@@ -30,6 +30,16 @@ export interface PiEmit {
   error?: string; // a model/turn error Pi reports IN the message (it still exits 0) — must be surfaced loudly
 }
 
+export function piCommand(env: NodeJS.ProcessEnv): string {
+  return env.OPEN_TAG_PI_COMMAND?.trim() || "pi";
+}
+
+export function piNoJsonError(jsonEventCount: number): string | null {
+  return jsonEventCount === 0
+    ? "pi exited 0 without parseable JSON events; check OPEN_TAG_PI_COMMAND and --mode json forwarding"
+    : null;
+}
+
 // handlePiEvent maps one parsed `pi -p --mode json` event to open-tag callbacks. Verified vs pi 0.73.1:
 // a `session` event carries `.id`; `message_end` carries `.message` (role + content[] blocks of
 // {type:"text",text} and {type:"toolCall",name,arguments}, plus stopReason/errorMessage). We read
@@ -127,16 +137,18 @@ class PiRun {
     }
     this.cb.onActivity("working", "turn");
     const args = buildArgs(prompt, this.opts.model, this.sessionId, this.opts.stateDir, this.promptFile);
-    const proc = spawnSafe("pi", args, { cwd: this.opts.cwd, stdio: ["ignore", "pipe", "pipe"], env: this.env });
+    const proc = spawnSafe(piCommand(this.env), args, { cwd: this.opts.cwd, stdio: ["ignore", "pipe", "pipe"], env: this.env });
     this.proc = proc;
     proc.once("spawn", () => { input.admission.accept(); if (input.initial) this.admission.accept(); });
     let buf = "";
     let turnFailed = false;
     const errTail: string[] = [];
     let errLen = 0;
+    let jsonEventCount = 0;
     const processLine = (ln: string) => {
       const t = ln.trim(); if (!t) return;
       let evt: any; try { evt = JSON.parse(t); } catch { return; }
+      jsonEventCount++;
       const emit = handlePiEvent(evt);
       if (emit.sessionId && emit.sessionId !== this.sessionId) { this.sessionId = emit.sessionId; this.cb.onSession(emit.sessionId); }
       if (emit.trajectory.length) this.cb.onTrajectory(emit.trajectory);
@@ -169,6 +181,15 @@ class PiRun {
       this.proc = null; this.turnBusy = false; if (this.stopped) { this.reportExit(code); return; }
       if (this.currentInput === input) this.currentInput = null;
       if (code === 0) {
+        const noJsonError = piNoJsonError(jsonEventCount);
+        if (noJsonError) {
+          const error = new Error(noJsonError);
+          this.cb.onTrajectory([{ kind: "text", text: "[pi error] " + noJsonError }]);
+          this.cb.onActivity("error", noJsonError);
+          if (!this.everSucceeded) { this.rejectQueue(error); this.reportExit(1); return; }
+          this.pump();
+          return;
+        }
         if (turnFailed) {
           if (!this.everSucceeded) { this.rejectQueue(new Error("pi initial turn failed")); this.reportExit(1); return; }
           this.cb.onAcceptedTurnFailure?.(input); this.pump(); return;


### PR DESCRIPTION
Pi follows  if set and treats successful exits with no JSON output as an explicit failure. Added README and runtime test coverage.